### PR TITLE
Update find_code_flaws.py

### DIFF
--- a/scripts/find_code_flaws.py
+++ b/scripts/find_code_flaws.py
@@ -220,8 +220,8 @@ def find_flawfinder( flawfinder_bin, verbose = True ) :
                # Let the use know that we have FLAWFINDER_HOME and where it is.
                TrickHLAMessage.status( 'FLAWFINDER_HOME: ' + flawfinder_home )
 
-               # Form the flawfinder command based on FLAWFINDER_HOME.
-               flawfinder_command = flawfinder_home + '/flawfinder'
+            # Form the flawfinder command based on FLAWFINDER_HOME.
+            flawfinder_command = flawfinder_home + '/flawfinder'
 
          else :
             TrickHLAMessage.failure( 'FLAWFINDER_HOME not found: ' + flawfinder_home )


### PR DESCRIPTION
fixed following bug:
- if FLAWFINDER_HOME environment variable exists and is a valid directory, the flawfinder_command variable would only got set when verbose mode is true.