### PR TITLE
Updated lag compensation to address issue #128

### DIFF
--- a/include/TrickHLA/LagCompensation.hh
+++ b/include/TrickHLA/LagCompensation.hh
@@ -78,7 +78,32 @@ class LagCompensation
       return;
    }
 
-  public:
+   //-----------------------------------------------------------------
+   // These are virtual functions and must be defined by a full class.
+   //-----------------------------------------------------------------
+
+   /*! @brief Send side lag compensation callback. */
+   virtual void send_lag_compensation();
+
+   /*! @brief When lag compensation is disabled, this function is called to
+    * bypass the send side lag compensation and your implementation must copy
+    * the sim-data to the lag-comp data to effect the bypass. */
+   virtual void bypass_send_lag_compensation() = 0;
+
+   /*! @brief Receive side lag compensation callback. */
+   virtual void receive_lag_compensation();
+
+   /*! @brief When lag compensation is disabled, this function is called to
+    * bypass the receive side lag compensation and your implementation must
+    * copy the lag-comp data to the sim-data to effect the bypass. You must
+    * make sure to check the lag-comp data was received before copying to
+    * the sim-data otherwise you will be copying stale data. */
+   virtual void bypass_receive_lag_compensation() = 0;
+
+   //-----------------------------------------------------------------
+   // Helper functions.
+   //-----------------------------------------------------------------
+
    /*! @brief Get the Attribute by FOM name.
     *  @return Attribute for the given name.
     *  @param attr_FOM_name Attribute FOM name. */
@@ -109,24 +134,6 @@ class LagCompensation
    /*! @brief Initialize the callback object to the supplied Object pointer.
     *  @param obj Associated object for this class. */
    virtual void initialize_callback( Object *obj );
-
-   //-----------------------------------------------------------------
-   // These are virtual functions and must be defined by a full class.
-   //-----------------------------------------------------------------
-
-   /*! @brief Send side lag compensation callback. */
-   virtual void send_lag_compensation() = 0;
-
-   /*! @brief When lag compensation is disabled, this function is called to
-    * bypass the send side lag compensation so data state can be copied over. */
-   virtual void bypass_send_lag_compensation() = 0;
-
-   /*! @brief Receive side lag compensation callback. */
-   virtual void receive_lag_compensation() = 0;
-
-   /*! @brief When lag compensation is disabled, this function is called to
-    * bypass the receive side lag compensation so data state can be copied over. */
-   virtual void bypass_receive_lag_compensation() = 0;
 
   protected:
    Object *object; ///< @trick_io{**} Object associated with this lag-comp class.

--- a/include/TrickHLA/LagCompensation.hh
+++ b/include/TrickHLA/LagCompensation.hh
@@ -31,6 +31,7 @@ NASA, Johnson Space Center\n
 @rev_entry{Dan Dexter, L3 Titan Group, DSES, June 2006, --, DSES Initial Lag Compensation.}
 @rev_entry{Dan Dexter, NASA ER7, TrickHLA, March 2019, --, Version 2 origin.}
 @rev_entry{Edwin Z. Crues, NASA ER7, TrickHLA, March 2019, --, Version 3 rewrite.}
+@rev_entry{Dan Dexter, NASA ER6, TrickHLA, October 2023, --, Added lag-comp bypass functions.}
 @revs_end
 
 */
@@ -114,10 +115,18 @@ class LagCompensation
    //-----------------------------------------------------------------
 
    /*! @brief Send side lag compensation callback. */
-   virtual void send_lag_compensation();
+   virtual void send_lag_compensation() = 0;
+
+   /*! @brief When lag compensation is disabled, this function is called to
+    * bypass the send side lag compensation so data state can be copied over. */
+   virtual void bypass_send_lag_compensation() = 0;
 
    /*! @brief Receive side lag compensation callback. */
-   virtual void receive_lag_compensation();
+   virtual void receive_lag_compensation() = 0;
+
+   /*! @brief When lag compensation is disabled, this function is called to
+    * bypass the receive side lag compensation so data state can be copied over. */
+   virtual void bypass_receive_lag_compensation() = 0;
 
   protected:
    Object *object; ///< @trick_io{**} Object associated with this lag-comp class.

--- a/include/TrickHLA/Packing.hh
+++ b/include/TrickHLA/Packing.hh
@@ -71,6 +71,24 @@ class Packing
    /*! @brief Destructor for the TrickHLA Packing class. */
    virtual ~Packing();
 
+   //-----------------------------------------------------------------
+   // These are virtual functions and must be defined by a full class.
+   //-----------------------------------------------------------------
+
+   /*! @brief Pack the data before being sent. */
+   virtual void pack() = 0;
+
+   /*! @brief Unpack the received data. */
+   virtual void unpack() = 0;
+
+   //-----------------------------------------------------------------
+   // Helper functions.
+   //-----------------------------------------------------------------
+
+   /*! @brief Initialize the callback object to the supplied Object pointer.
+    *  @param obj Associated object for this class. */
+   virtual void initialize_callback( Object *obj );
+
    /*! @brief Get the Attribute by FOM name.
     *  @return Attribute for the given name.
     *  @param attr_FOM_name Attribute FOM name. */
@@ -88,20 +106,6 @@ class Packing
    /*! @brief Get the current Central Timing Equipment (CTE) time.
     *  @return Returns the current CTE time. */
    double get_cte_time();
-
-   /*! @brief Initialize the callback object to the supplied Object pointer.
-    *  @param obj Associated object for this class. */
-   virtual void initialize_callback( Object *obj );
-
-   //-----------------------------------------------------------------
-   // These are virtual functions and must be defined by a full class.
-   //-----------------------------------------------------------------
-
-   /*! @brief Pack the data before being sent. */
-   virtual void pack() = 0;
-
-   /*! @brief Unpack the received data. The default */
-   virtual void unpack() = 0;
 
   protected:
    Object *object; ///< @trick_io{**} Object associated with this packing class.

--- a/models/simconfig/src/SimpleSimConfig.cpp
+++ b/models/simconfig/src/SimpleSimConfig.cpp
@@ -21,7 +21,6 @@ NASA, Johnson Space Center\n
 @tldh
 @trick_link_dependency{../source/TrickHLA/DebugHandler.cpp}
 @trick_link_dependency{../source/TrickHLA/Int64BaseTime.cpp}
-@trick_link_dependency{../source/TrickHLA/Int64Interval.cpp}
 @trick_link_dependency{../source/TrickHLA/Object.cpp}
 @trick_link_dependency{../source/TrickHLA/Types.cpp}
 @trick_link_dependency{simconfig/src/SimpleSimConfig.cpp}
@@ -48,7 +47,7 @@ NASA, Johnson Space Center\n
 // TrickHLA include files.
 #include "TrickHLA/DebugHandler.hh"
 #include "TrickHLA/Int64BaseTime.hh"
-#include "TrickHLA/Int64Interval.hh"
+#include "TrickHLA/KnownFederate.hh"
 #include "TrickHLA/Object.hh"
 #include "TrickHLA/Types.hh"
 

--- a/models/sine/include/SineData.hh
+++ b/models/sine/include/SineData.hh
@@ -190,17 +190,7 @@ class SineData
 
    /*! @brief Set the name of the sine wave object.
     *  @param new_name The name of the sine wave object. */
-   void set_name( char const *new_name )
-   {
-      if ( new_name != this->name ) {
-         if ( this->name != NULL ) {
-            if ( trick_MM->delete_var( static_cast< void * >( this->name ) ) ) {
-               send_hs( stderr, "TrickHLAModel::SineData::set_name():%d ERROR deleting Trick Memory for 'this->name'\n", __LINE__ );
-            }
-         }
-         this->name = ( new_name != NULL ) ? trick_MM->mm_strdup( new_name ) : NULL;
-      }
-   }
+   void set_name( char const *new_name );
 
    //
    // Public utility functions.

--- a/models/sine/include/SineLagCompensation.hh
+++ b/models/sine/include/SineLagCompensation.hh
@@ -29,6 +29,7 @@ NASA, Johnson Space Center\n
 @revs_begin
 @rev_entry{Dan Dexter, NASA ER7, TrickHLA, June 2006, --, Version 2 origin.}
 @rev_entry{Edwin Z. Crues, NASA ER7, TrickHLA, March 2020, --, Version 3 rewrite.}
+@rev_entry{Dan Dexter, NASA ER6, TrickHLA, October 2023, --, Added lag-comp bypass functions.}
 @revs_end
 
 */
@@ -89,9 +90,17 @@ class SineLagCompensation : public TrickHLA::LagCompensation
     *  head by dt to predict the value at the next data cycle. */
    virtual void send_lag_compensation();
 
+   /*! @brief When lag compensation is disabled, this function is called to
+    * bypass the send side lag compensation so data state can be copied over. */
+   virtual void bypass_send_lag_compensation();
+
    /*! @brief Receive side lag-compensation where we propagate the sine wave
     *  state ahead by dt to predict the value at the next data cycle. */
    virtual void receive_lag_compensation();
+
+   /*! @brief When lag compensation is disabled, this function is called to
+    * bypass the receive side lag compensation so data state can be copied over. */
+   virtual void bypass_receive_lag_compensation();
 
   private:
    SineData *sim_data;      ///< @trick_units{--} Simulation data.

--- a/models/sine/include/SineLagCompensation.hh
+++ b/models/sine/include/SineLagCompensation.hh
@@ -53,7 +53,7 @@ class Object;
 namespace TrickHLAModel
 {
 
-class SineLagCompensation : public TrickHLA::LagCompensation
+class SineLagCompensation : public SineData, public TrickHLA::LagCompensation
 {
    // Let the Trick input processor access protected and private data.
    // InputProcessor is really just a marker class (does not really
@@ -75,9 +75,8 @@ class SineLagCompensation : public TrickHLA::LagCompensation
    virtual ~SineLagCompensation();
 
    /*! @brief Initialize the LagCompensation object.
-    *  @param sim_data      The sine wave data object.
-    *  @param lag_comp_data The sine wave lag compensation data. */
-   void initialize( SineData *sim_data, SineData *lag_comp_data );
+    *  @param sim_data The sine wave data object. */
+   void initialize( SineData *sim_data );
 
    //
    // From the TrickHLALag::Compensation class.
@@ -103,8 +102,7 @@ class SineLagCompensation : public TrickHLA::LagCompensation
    virtual void bypass_receive_lag_compensation();
 
   private:
-   SineData *sim_data;      ///< @trick_units{--} Simulation data.
-   SineData *lag_comp_data; ///< @trick_units{--} Lag compensation data.
+   SineData *sim_data; ///< @trick_units{--} Simulation data.
 
    TrickHLA::Attribute *time_attr;  ///< @trick_io{**} Reference to the "Time" TrickHLA::Attribute.
    TrickHLA::Attribute *value_attr; ///< @trick_io{**} Reference to the "Value" TrickHLA::Attribute.

--- a/models/sine/include/SineLagCompensation.hh
+++ b/models/sine/include/SineLagCompensation.hh
@@ -22,6 +22,7 @@ NASA, Johnson Space Center\n
 @trick_link_dependency{../source/TrickHLA/Attribute.cpp}
 @trick_link_dependency{../source/TrickHLA/LagCompensation.cpp}
 @trick_link_dependency{../source/TrickHLA/Object.cpp}
+@trick_link_dependency{../source/TrickHLA/Types.cpp}
 @trick_link_dependency{sine/src/SineData.cpp}
 @trick_link_dependency{sine/src/SineLagCompensation.cpp}
 
@@ -37,15 +38,14 @@ NASA, Johnson Space Center\n
 #ifndef TRICKHLA_MODLE_SINE_LAG_COMPENSATION_HH
 #define TRICKHLA_MODLE_SINE_LAG_COMPENSATION_HH
 
-// Forward declarations.
-namespace TrickHLA
-{
-class Object;
-}
+// System include files.
+#include <string>
 
 // TrickHLA include files.
 #include "TrickHLA/Attribute.hh"
 #include "TrickHLA/LagCompensation.hh"
+#include "TrickHLA/Object.hh"
+#include "TrickHLA/Types.hh"
 
 // Model include files.
 #include "SineData.hh"
@@ -90,7 +90,8 @@ class SineLagCompensation : public SineData, public TrickHLA::LagCompensation
    virtual void send_lag_compensation();
 
    /*! @brief When lag compensation is disabled, this function is called to
-    * bypass the send side lag compensation so data state can be copied over. */
+    * bypass the send side lag compensation and your implementation must copy
+    * the sim-data to the lag-comp data to effect the bypass. */
    virtual void bypass_send_lag_compensation();
 
    /*! @brief Receive side lag-compensation where we propagate the sine wave
@@ -98,7 +99,8 @@ class SineLagCompensation : public SineData, public TrickHLA::LagCompensation
    virtual void receive_lag_compensation();
 
    /*! @brief When lag compensation is disabled, this function is called to
-    * bypass the receive side lag compensation so data state can be copied over. */
+    * bypass the receive side lag compensation and your implementation must
+    * copy the lag-comp data to the sim-data to effect the bypass. */
    virtual void bypass_receive_lag_compensation();
 
   private:
@@ -112,6 +114,8 @@ class SineLagCompensation : public SineData, public TrickHLA::LagCompensation
    TrickHLA::Attribute *amp_attr;   ///< @trick_io{**} Reference to the "Amplitude" TrickHLA::Attribute.
    TrickHLA::Attribute *tol_attr;   ///< @trick_io{**} Reference to the "Tolerance" TrickHLA::Attribute.
    TrickHLA::Attribute *name_attr;  ///< @trick_io{**} Reference to the "Name" TrickHLA::Attribute.
+
+   std::string lag_comp_type_str; ///< @trick_units{--} Type of lag compensation as a string.
 
   private:
    // Do not allow the copy constructor or assignment operator.

--- a/models/sine/include/SineObjectDeleted.hh
+++ b/models/sine/include/SineObjectDeleted.hh
@@ -34,13 +34,8 @@ NASA, Johnson Space Center\n
 #ifndef TRICKHLA_MODLE_SINE_OBJECT_DELETED_HH
 #define TRICKHLA_MODLE_SINE_OBJECT_DELETED_HH
 
-// Forward declarations.
-namespace TrickHLA
-{
-class Object;
-}
-
 // Trick include files.
+#include "TrickHLA/Object.hh"
 #include "TrickHLA/ObjectDeleted.hh"
 
 namespace TrickHLAModel

--- a/models/sine/include/SineOwnershipHandler.hh
+++ b/models/sine/include/SineOwnershipHandler.hh
@@ -34,13 +34,8 @@ NASA, Johnson Space Center\n
 #ifndef TRICKHLA_MODEL_SINE_OWNERSHIP_HANDLER_HH
 #define TRICKHLA_MODEL_SINE_OWNERSHIP_HANDLER_HH
 
-// Forward declarations.
-namespace TrickHLA
-{
-class Object;
-}
-
 // TrickHLA include files.
+#include "TrickHLA/Object.hh"
 #include "TrickHLA/OwnershipHandler.hh"
 
 namespace TrickHLAModel

--- a/models/sine/include/SinePacking.hh
+++ b/models/sine/include/SinePacking.hh
@@ -36,14 +36,9 @@ NASA, Johnson Space Center\n
 #ifndef TRICKHLA_MODEL_SINE_PACKING_HH
 #define TRICKHLA_MODEL_SINE_PACKING_HH
 
-// Forward declarations.
-namespace TrickHLA
-{
-class Object;
-}
-
 // TrickHLA include files.
 #include "TrickHLA/Attribute.hh"
+#include "TrickHLA/Object.hh"
 #include "TrickHLA/Packing.hh"
 
 // Model include files.

--- a/models/sine/include/SinePacking.hh
+++ b/models/sine/include/SinePacking.hh
@@ -52,7 +52,7 @@ class Object;
 namespace TrickHLAModel
 {
 
-class SinePacking : public TrickHLA::Packing
+class SinePacking : public SineData, public TrickHLA::Packing
 {
    // Let the Trick input processor access protected and private data.
    // InputProcessor is really just a marker class (does not really

--- a/models/sine/src/SineData.cpp
+++ b/models/sine/src/SineData.cpp
@@ -54,6 +54,9 @@ SineData::SineData()
      tol( 0.001 ),
      name( NULL )
 {
+   // We don't want a NULL name by default (Trick Memory Manager allocated).
+   this->set_name( "" );
+
    // Compute the value.
    this->compute_value( time );
 
@@ -77,6 +80,9 @@ SineData::SineData(
      tol( 0.001 ),
      name( NULL )
 {
+   // We don't want a NULL name by default (Trick Memory Manager allocated).
+   this->set_name( "" );
+
    // Compute the value.
    this->compute_value( time );
 
@@ -99,13 +105,53 @@ SineData::~SineData()
 }
 
 /*!
+ * @brief Set the name of the sine wave object.
+ * @param new_name The name of the sine wave object.
+ */
+void SineData::set_name( char const *new_name )
+{
+   if ( new_name != this->name ) {
+      if ( this->name != NULL ) {
+         if ( trick_MM->delete_var( static_cast< void * >( this->name ) ) ) {
+            send_hs( stderr, "TrickHLAModel::SineData::set_name():%d ERROR deleting Trick Memory for 'this->name'\n", __LINE__ );
+            exit( -1 );
+         }
+      }
+      if ( new_name != NULL ) {
+         this->name = trick_MM->mm_strdup( new_name );
+         if ( this->name == NULL ) {
+            send_hs( stderr, "TrickHLAModel::SineData::set_name():%d ERROR cannot allocate Trick Memory for 'this->name'\n", __LINE__ );
+            exit( -1 );
+         }
+      } else {
+         this->name = NULL;
+      }
+   }
+
+   // We don't want a NULL name by default (Trick Memory Manager allocated).
+   if ( this->name == NULL ) {
+      this->name = trick_MM->mm_strdup( "" );
+      if ( this->name == NULL ) {
+         send_hs( stderr, "TrickHLAModel::SineData::set_name():%d ERROR cannot allocate Trick Memory for 'this->name'\n", __LINE__ );
+         exit( -1 );
+      }
+   }
+}
+
+/*!
  * @job_class{scheduled}
  */
 void SineData::copy_data(
-   SineData const *orig ) // IN: -- Orginal source data to copy.
+   SineData const *orig ) // IN: -- Original source data to copy from.
 {
-   // Use the default assignment operator to copy.
-   *this = *orig;
+   this->set_name( orig->get_name() );
+   this->set_time( orig->get_time() );
+   this->set_value( orig->get_value() );
+   this->set_derivative( orig->get_derivative() );
+   this->set_phase( orig->get_phase() );
+   this->set_frequency( orig->get_frequency() );
+   this->set_amplitude( orig->get_amplitude() );
+   this->set_tolerance( orig->get_tolerance() );
 }
 
 /*!

--- a/models/sine/src/SineInteractionHandler.cpp
+++ b/models/sine/src/SineInteractionHandler.cpp
@@ -64,7 +64,8 @@ using namespace TrickHLAModel;
  * @job_class{initialization}
  */
 SineInteractionHandler::SineInteractionHandler()
-   : name( NULL ),
+   : TrickHLA::InteractionHandler(),
+     name( NULL ),
      message( NULL ),
      time( 0.0 ),
      year( 2007 ),

--- a/models/sine/src/SineInteractionHandler.cpp
+++ b/models/sine/src/SineInteractionHandler.cpp
@@ -21,6 +21,7 @@ NASA, Johnson Space Center\n
 @tldh
 @trick_link_dependency{../source/TrickHLA/DebugHandler.cpp}
 @trick_link_dependency{../source/TrickHLA/Int64BaseTime.cpp}
+@trick_link_dependency{../source/TrickHLA/InteractionHandler.cpp}
 @trick_link_dependency{../source/TrickHLA/Types.cpp}
 @trick_link_dependency{sine/src/SineInteractionHandler.cpp}
 
@@ -49,6 +50,7 @@ NASA, Johnson Space Center\n
 // TrickHLA include files.
 #include "TrickHLA/DebugHandler.hh"
 #include "TrickHLA/Int64BaseTime.hh"
+#include "TrickHLA/InteractionHandler.hh"
 #include "TrickHLA/StandardsSupport.hh"
 #include "TrickHLA/StringUtilities.hh"
 #include "TrickHLA/Types.hh"

--- a/models/sine/src/SineLagCompensation.cpp
+++ b/models/sine/src/SineLagCompensation.cpp
@@ -147,7 +147,10 @@ void SineLagCompensation::send_lag_compensation()
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
+
       cout << "******* SineLagCompensation::send_lag_compensation():" << __LINE__ << endl
+           << "    object-name:'" << obj_name << "'" << endl
            << " lag-comp-type:" << lag_comp_type_str << endl
            << " scenario-time:" << setprecision( 18 ) << get_scenario_time() << endl
            << "     data-time:" << setprecision( 18 ) << sim_data->get_time() << endl
@@ -180,7 +183,10 @@ void SineLagCompensation::bypass_send_lag_compensation()
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
+
       cout << "******* SineLagCompensation::bypass_send_lag_compensation():" << __LINE__ << endl
+           << "   object-name:'" << obj_name << "'" << endl
            << " lag-comp-type:" << lag_comp_type_str << endl
            << " scenario-time:" << setprecision( 18 ) << get_scenario_time() << endl
            << "     data-time:" << setprecision( 18 ) << sim_data->get_time() << endl;
@@ -210,7 +216,10 @@ void SineLagCompensation::receive_lag_compensation()
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
+
       cout << "******* SineLagCompensation::receive_lag_compensation():" << __LINE__ << endl
+           << "   object-name:'" << obj_name << "'" << endl
            << " lag-comp-type:" << lag_comp_type_str << endl
            << " scenario-time:" << setprecision( 18 ) << get_scenario_time() << endl;
       if ( time_attr->is_received() ) {
@@ -318,7 +327,10 @@ void SineLagCompensation::bypass_receive_lag_compensation()
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
+
       cout << "******* SineLagCompensation::bypass_receive_lag_compensation():" << __LINE__ << endl
+           << "   object-name:'" << obj_name << "'" << endl
            << " lag-comp-type:" << lag_comp_type_str << endl
            << " scenario-time:" << setprecision( 18 ) << get_scenario_time() << endl;
       if ( time_attr->is_received() ) {

--- a/models/sine/src/SineLagCompensation.cpp
+++ b/models/sine/src/SineLagCompensation.cpp
@@ -54,8 +54,9 @@ using namespace TrickHLAModel;
  * @job_class{initialization}
  */
 SineLagCompensation::SineLagCompensation()
-   : sim_data( NULL ),
-     lag_comp_data( NULL ),
+   : SineData(),
+     TrickHLA::LagCompensation(),
+     sim_data( NULL ),
      time_attr( NULL ),
      value_attr( NULL ),
      dvdt_attr( NULL ),
@@ -80,11 +81,9 @@ SineLagCompensation::~SineLagCompensation()
  * @job_class{initialization}
  */
 void SineLagCompensation::initialize(
-   SineData *sim_data,
-   SineData *lag_comp_data )
+   SineData *sim_data )
 {
-   this->sim_data      = sim_data;
-   this->lag_comp_data = lag_comp_data;
+   this->sim_data = sim_data;
 }
 
 /*!
@@ -128,21 +127,21 @@ void SineLagCompensation::send_lag_compensation()
    }
 
    // Copy the data if the pointers are not the same.
-   if ( lag_comp_data != sim_data ) {
+   if ( this != sim_data ) {
       // Copy the current sine state over to the predicted sine state.
-      lag_comp_data->set_name( sim_data->get_name() );
-      lag_comp_data->set_value( sim_data->get_value() );
-      lag_comp_data->set_derivative( sim_data->get_derivative() );
-      lag_comp_data->set_phase( sim_data->get_phase() );
-      lag_comp_data->set_frequency( sim_data->get_frequency() );
-      lag_comp_data->set_amplitude( sim_data->get_amplitude() );
-      lag_comp_data->set_tolerance( sim_data->get_tolerance() );
+      this->set_name( sim_data->get_name() );
+      this->set_value( sim_data->get_value() );
+      this->set_derivative( sim_data->get_derivative() );
+      this->set_phase( sim_data->get_phase() );
+      this->set_frequency( sim_data->get_frequency() );
+      this->set_amplitude( sim_data->get_amplitude() );
+      this->set_tolerance( sim_data->get_tolerance() );
    }
 
-   lag_comp_data->set_time( time );
+   this->set_time( time );
 
-   lag_comp_data->compute_value( time );
-   lag_comp_data->compute_derivative( time );
+   this->compute_value( time );
+   this->compute_derivative( time );
 }
 
 void SineLagCompensation::bypass_send_lag_compensation()
@@ -158,54 +157,54 @@ void SineLagCompensation::bypass_send_lag_compensation()
    // Bypass send lag compensation by copying the current sim-data to the
    // lag-comp data structure. We need to ensure the lac-comp data structure
    // is updated to ensure any downstream calculations still get data.
-   if ( lag_comp_data != sim_data ) {
-      lag_comp_data->set_name( sim_data->get_name() );
-      lag_comp_data->set_time( sim_data->get_time() );
-      lag_comp_data->set_value( sim_data->get_value() );
-      lag_comp_data->set_derivative( sim_data->get_derivative() );
-      lag_comp_data->set_phase( sim_data->get_phase() );
-      lag_comp_data->set_frequency( sim_data->get_frequency() );
-      lag_comp_data->set_amplitude( sim_data->get_amplitude() );
-      lag_comp_data->set_tolerance( sim_data->get_tolerance() );
+   if ( this != sim_data ) {
+      this->set_name( sim_data->get_name() );
+      this->set_time( sim_data->get_time() );
+      this->set_value( sim_data->get_value() );
+      this->set_derivative( sim_data->get_derivative() );
+      this->set_phase( sim_data->get_phase() );
+      this->set_frequency( sim_data->get_frequency() );
+      this->set_amplitude( sim_data->get_amplitude() );
+      this->set_tolerance( sim_data->get_tolerance() );
    }
 }
 
 void SineLagCompensation::receive_lag_compensation()
 {
    double const time = get_scenario_time();
-   double const dt   = time - lag_comp_data->get_time();
+   double const dt   = time - this->get_time();
 
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
       cout << "******* SineLagCompensation::receive_lag_compensation():" << __LINE__ << endl
            << " scenario-time:" << get_scenario_time() << endl
-           << "     data-time:" << lag_comp_data->get_time() << endl
+           << "     data-time:" << this->get_time() << endl
            << "            dt:" << dt << endl
            << " adjusted-time:" << time << endl
            << " BEFORE Lag Compensation:" << endl
-           << "\t Name  lag_comp_data: '" << lag_comp_data->get_name()
+           << "\t Name  this: '" << this->get_name()
            << "', received update:" << ( name_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Time  lag_comp_data: " << lag_comp_data->get_time()
+           << "\t Time  this: " << this->get_time()
            << ", received update:" << ( time_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Value lag_comp_data: " << lag_comp_data->get_value()
+           << "\t Value this: " << this->get_value()
            << ", received update:" << ( value_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t dvdt  lag_comp_data: " << lag_comp_data->get_derivative()
+           << "\t dvdt  this: " << this->get_derivative()
            << ", received update:" << ( dvdt_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Phase lag_comp_data: " << lag_comp_data->get_phase()
+           << "\t Phase this: " << this->get_phase()
            << ", received update:" << ( phase_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Amp   lag_comp_data: " << lag_comp_data->get_amplitude()
+           << "\t Amp   this: " << this->get_amplitude()
            << ", received update:" << ( amp_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Freq  lag_comp_data: " << lag_comp_data->get_frequency()
+           << "\t Freq  this: " << this->get_frequency()
            << ", received update:" << ( freq_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Tol   lag_comp_data: " << lag_comp_data->get_tolerance()
+           << "\t Tol   this: " << this->get_tolerance()
            << ", received update:" << ( tol_attr->is_received() ? "Yes" : "No" ) << endl;
    }
 
@@ -220,25 +219,25 @@ void SineLagCompensation::receive_lag_compensation()
    // Because of ownership transfers and attributes being sent at different
    // rates we need to check to see if we received data for each attribute.
    if ( name_attr->is_received() ) {
-      sim_data->set_name( lag_comp_data->get_name() );
+      sim_data->set_name( this->get_name() );
    }
    if ( value_attr->is_received() ) {
-      sim_data->set_value( lag_comp_data->get_value() );
+      sim_data->set_value( this->get_value() );
    }
    if ( dvdt_attr->is_received() ) {
-      sim_data->set_derivative( lag_comp_data->get_derivative() );
+      sim_data->set_derivative( this->get_derivative() );
    }
    if ( phase_attr->is_received() ) {
-      sim_data->set_phase( lag_comp_data->get_phase() );
+      sim_data->set_phase( this->get_phase() );
    }
    if ( freq_attr->is_received() ) {
-      sim_data->set_frequency( lag_comp_data->get_frequency() );
+      sim_data->set_frequency( this->get_frequency() );
    }
    if ( amp_attr->is_received() ) {
-      sim_data->set_amplitude( lag_comp_data->get_amplitude() );
+      sim_data->set_amplitude( this->get_amplitude() );
    }
    if ( tol_attr->is_received() ) {
-      sim_data->set_tolerance( lag_comp_data->get_tolerance() );
+      sim_data->set_tolerance( this->get_tolerance() );
    }
 
    sim_data->set_time( time );
@@ -268,39 +267,39 @@ void SineLagCompensation::receive_lag_compensation()
 void SineLagCompensation::bypass_receive_lag_compensation()
 {
    double const time = get_scenario_time();
-   double const dt   = time - lag_comp_data->get_time();
+   double const dt   = time - this->get_time();
 
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
       cout << "******* SineLagCompensation::bypass_receive_lag_compensation():" << __LINE__ << endl
            << " scenario-time:" << get_scenario_time() << endl
-           << "     data-time:" << lag_comp_data->get_time() << endl
+           << "     data-time:" << this->get_time() << endl
            << "            dt:" << dt << endl
            << " adjusted-time:" << time << endl
            << " BEFORE Bypassing Lag Compensation:" << endl
-           << "\t Name  lag_comp_data: '" << lag_comp_data->get_name()
+           << "\t Name  this: '" << this->get_name()
            << "', received update:" << ( name_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Time  lag_comp_data: " << lag_comp_data->get_time()
+           << "\t Time  this: " << this->get_time()
            << ", received update:" << ( time_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Value lag_comp_data: " << lag_comp_data->get_value()
+           << "\t Value this: " << this->get_value()
            << ", received update:" << ( value_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t dvdt  lag_comp_data: " << lag_comp_data->get_derivative()
+           << "\t dvdt  this: " << this->get_derivative()
            << ", received update:" << ( dvdt_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Phase lag_comp_data: " << lag_comp_data->get_phase()
+           << "\t Phase this: " << this->get_phase()
            << ", received update:" << ( phase_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Amp   lag_comp_data: " << lag_comp_data->get_amplitude()
+           << "\t Amp   this: " << this->get_amplitude()
            << ", received update:" << ( amp_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Freq  lag_comp_data: " << lag_comp_data->get_frequency()
+           << "\t Freq  this: " << this->get_frequency()
            << ", received update:" << ( freq_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t Tol   lag_comp_data: " << lag_comp_data->get_tolerance()
+           << "\t Tol   this: " << this->get_tolerance()
            << ", received update:" << ( tol_attr->is_received() ? "Yes" : "No" ) << endl;
    }
 
@@ -317,28 +316,28 @@ void SineLagCompensation::bypass_receive_lag_compensation()
 
    // Bypass receive lag compensation by copying lag-comp data to sim-data.
    if ( name_attr->is_received() ) {
-      sim_data->set_name( lag_comp_data->get_name() );
+      sim_data->set_name( this->get_name() );
    }
    if ( time_attr->is_received() ) {
-      sim_data->set_time( lag_comp_data->get_time() );
+      sim_data->set_time( this->get_time() );
    }
    if ( value_attr->is_received() ) {
-      sim_data->set_value( lag_comp_data->get_value() );
+      sim_data->set_value( this->get_value() );
    }
    if ( dvdt_attr->is_received() ) {
-      sim_data->set_derivative( lag_comp_data->get_derivative() );
+      sim_data->set_derivative( this->get_derivative() );
    }
    if ( phase_attr->is_received() ) {
-      sim_data->set_phase( lag_comp_data->get_phase() );
+      sim_data->set_phase( this->get_phase() );
    }
    if ( freq_attr->is_received() ) {
-      sim_data->set_frequency( lag_comp_data->get_frequency() );
+      sim_data->set_frequency( this->get_frequency() );
    }
    if ( amp_attr->is_received() ) {
-      sim_data->set_amplitude( lag_comp_data->get_amplitude() );
+      sim_data->set_amplitude( this->get_amplitude() );
    }
    if ( tol_attr->is_received() ) {
-      sim_data->set_tolerance( lag_comp_data->get_tolerance() );
+      sim_data->set_tolerance( this->get_tolerance() );
    }
 
    // Use the inherited debug-handler to allow debug comments to be turned

--- a/models/sine/src/SineLagCompensation.cpp
+++ b/models/sine/src/SineLagCompensation.cpp
@@ -23,6 +23,7 @@ NASA, Johnson Space Center\n
 @revs_begin
 @rev_entry{Dan Dexter, L3 Titan Group, DSES, June 2006, --, Initial implementation.}
 @rev_entry{Edwin Z. Crues, NASA ER7, TrickHLA, March 2020, --, Version 3 rewrite.}
+@rev_entry{Dan Dexter, NASA ER6, TrickHLA, October 2023, --, Added lag-comp bypass functions.}
 @revs_end
 
 */
@@ -101,6 +102,7 @@ void SineLagCompensation::initialize_callback(
    // Get a reference to the TrickHLA-Attribute for all the FOM attributes
    // names. We do this here so that we only do the attribute lookup once
    // instead of looking it up every time the unpack function is called.
+   name_attr  = get_attribute_and_validate( "Name" );
    time_attr  = get_attribute_and_validate( "Time" );
    value_attr = get_attribute_and_validate( "Value" );
    dvdt_attr  = get_attribute_and_validate( "dvdt" );
@@ -108,7 +110,6 @@ void SineLagCompensation::initialize_callback(
    freq_attr  = get_attribute_and_validate( "Frequency" );
    amp_attr   = get_attribute_and_validate( "Amplitude" );
    tol_attr   = get_attribute_and_validate( "Tolerance" );
-   name_attr  = get_attribute_and_validate( "Name" );
 }
 
 void SineLagCompensation::send_lag_compensation()
@@ -126,24 +127,51 @@ void SineLagCompensation::send_lag_compensation()
            << " adjusted-time:" << time << endl;
    }
 
+   // Copy the data if the pointers are not the same.
    if ( lag_comp_data != sim_data ) {
       // Copy the current sine state over to the predicted sine state.
-      *lag_comp_data = *sim_data;
+      lag_comp_data->set_name( sim_data->get_name() );
+      lag_comp_data->set_value( sim_data->get_value() );
+      lag_comp_data->set_derivative( sim_data->get_derivative() );
+      lag_comp_data->set_phase( sim_data->get_phase() );
+      lag_comp_data->set_frequency( sim_data->get_frequency() );
+      lag_comp_data->set_amplitude( sim_data->get_amplitude() );
+      lag_comp_data->set_tolerance( sim_data->get_tolerance() );
    }
+
+   lag_comp_data->set_time( time );
+
    lag_comp_data->compute_value( time );
    lag_comp_data->compute_derivative( time );
 }
 
+void SineLagCompensation::bypass_send_lag_compensation()
+{
+   // Use the inherited debug-handler to allow debug comments to be turned
+   // on and off from a setting in the input file.
+   if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      cout << "******* SineLagCompensation::bypass_send_lag_compensation():" << __LINE__ << endl
+           << " scenario-time:" << get_scenario_time() << endl
+           << "     data-time:" << sim_data->get_time() << endl;
+   }
+
+   // Bypass send lag compensation by copying the current sim-data to the
+   // lag-comp data structure. We need to ensure the lac-comp data structure
+   // is updated to ensure any downstream calculations still get data.
+   if ( lag_comp_data != sim_data ) {
+      lag_comp_data->set_name( sim_data->get_name() );
+      lag_comp_data->set_time( sim_data->get_time() );
+      lag_comp_data->set_value( sim_data->get_value() );
+      lag_comp_data->set_derivative( sim_data->get_derivative() );
+      lag_comp_data->set_phase( sim_data->get_phase() );
+      lag_comp_data->set_frequency( sim_data->get_frequency() );
+      lag_comp_data->set_amplitude( sim_data->get_amplitude() );
+      lag_comp_data->set_tolerance( sim_data->get_tolerance() );
+   }
+}
+
 void SineLagCompensation::receive_lag_compensation()
 {
-   // If the HLA time attribute has changed and is remotely owned (i.e. is
-   // coming from another federate) then override our simulation state with the
-   // incoming value. If we locally own the attribute then we do not want to
-   // override it's value. If we did not do this check then we would be
-   // overriding state of something we own and publish with whatever value
-   // happen to be in the local variable, which would cause data corruption of
-   // the state. We always need to do this check because ownership transfers
-   // could happen at any time or the data could be at a different rate.
    double const time = get_scenario_time();
    double const dt   = time - lag_comp_data->get_time();
 
@@ -154,22 +182,46 @@ void SineLagCompensation::receive_lag_compensation()
            << " scenario-time:" << get_scenario_time() << endl
            << "     data-time:" << lag_comp_data->get_time() << endl
            << "            dt:" << dt << endl
-           << " adjusted-time:" << time << endl;
-
-      cout << "SineLagCompensation::receive_lag_compensation():" << __LINE__
+           << " adjusted-time:" << time << endl
            << " BEFORE Lag Compensation:" << endl
-           << "\t Name \tlagging_data: " << lag_comp_data->get_name() << endl
-           << "\t Time \tlagging_data: " << lag_comp_data->get_time() << endl
-           << "\t Value \tlagging_data: " << lag_comp_data->get_value() << endl
-           << "\t dvdt \tlagging_data: " << lag_comp_data->get_derivative() << endl
-           << "\t Phase \tlagging_data: " << lag_comp_data->get_phase() << endl
-           << "\t Freq \tlagging_data: " << lag_comp_data->get_frequency() << endl
-           << "\t Amp \tlagging_data: " << lag_comp_data->get_amplitude() << endl
-           << "\t Tol \tlagging_data: " << lag_comp_data->get_tolerance() << endl;
+           << "\t Name  lag_comp_data: '" << lag_comp_data->get_name()
+           << "', received update:" << ( name_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Time  lag_comp_data: " << lag_comp_data->get_time()
+           << ", received update:" << ( time_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Value lag_comp_data: " << lag_comp_data->get_value()
+           << ", received update:" << ( value_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t dvdt  lag_comp_data: " << lag_comp_data->get_derivative()
+           << ", received update:" << ( dvdt_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Phase lag_comp_data: " << lag_comp_data->get_phase()
+           << ", received update:" << ( phase_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Amp   lag_comp_data: " << lag_comp_data->get_amplitude()
+           << ", received update:" << ( amp_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Freq  lag_comp_data: " << lag_comp_data->get_frequency()
+           << ", received update:" << ( freq_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Tol   lag_comp_data: " << lag_comp_data->get_tolerance()
+           << ", received update:" << ( tol_attr->is_received() ? "Yes" : "No" ) << endl;
    }
 
+   // If the HLA time attribute has changed and is remotely owned (i.e. is
+   // coming from another federate) then override our simulation state with the
+   // incoming value. If we locally own the attribute then we do not want to
+   // override it's value. If we did not do this check then we would be
+   // overriding state of something we own and publish with whatever value
+   // happen to be in the local variable, which would cause data corruption of
+   // the state. We always need to do this check because ownership transfers
+   // could happen at any time or the data could be at a different rate.
    // Because of ownership transfers and attributes being sent at different
    // rates we need to check to see if we received data for each attribute.
+   if ( name_attr->is_received() ) {
+      sim_data->set_name( lag_comp_data->get_name() );
+   }
    if ( value_attr->is_received() ) {
       sim_data->set_value( lag_comp_data->get_value() );
    }
@@ -188,9 +240,8 @@ void SineLagCompensation::receive_lag_compensation()
    if ( tol_attr->is_received() ) {
       sim_data->set_tolerance( lag_comp_data->get_tolerance() );
    }
-   if ( name_attr->is_received() ) {
-      sim_data->set_name( lag_comp_data->get_name() );
-   }
+
+   sim_data->set_time( time );
 
    // Do the lag compensation by computing values to the time.
    sim_data->compute_value( time );
@@ -201,15 +252,107 @@ void SineLagCompensation::receive_lag_compensation()
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
-      cout << "SineLagCompensation::receive_lag_compensation():" << __LINE__
+      cout << "SineLagCompensation::receive_lag_compensation():" << __LINE__ << endl
            << " AFTER LAG COMPENSATION:" << endl
-           << "\t Name \tsim_data: " << sim_data->get_name() << endl
-           << "\t Time \tsim_data: " << sim_data->get_time() << endl
-           << "\t Value \tsim_data: " << sim_data->get_value() << endl
-           << "\t dvdt \tsim_data: " << sim_data->get_derivative() << endl
-           << "\t Phase \tsim_data: " << sim_data->get_phase() << endl
-           << "\t Freq \tsim_data: " << sim_data->get_frequency() << endl
-           << "\t Amp \tsim_data: " << sim_data->get_amplitude() << endl
-           << "\t Tol \tsim_data: " << sim_data->get_tolerance() << endl;
+           << "\t Name  sim_data: '" << sim_data->get_name() << "'" << endl
+           << "\t Time  sim_data: " << sim_data->get_time() << endl
+           << "\t Value sim_data: " << sim_data->get_value() << endl
+           << "\t dvdt  sim_data: " << sim_data->get_derivative() << endl
+           << "\t Phase sim_data: " << sim_data->get_phase() << endl
+           << "\t Amp   sim_data: " << sim_data->get_amplitude() << endl
+           << "\t Freq  sim_data: " << sim_data->get_frequency() << endl
+           << "\t Tol   sim_data: " << sim_data->get_tolerance() << endl;
+   }
+}
+
+void SineLagCompensation::bypass_receive_lag_compensation()
+{
+   double const time = get_scenario_time();
+   double const dt   = time - lag_comp_data->get_time();
+
+   // Use the inherited debug-handler to allow debug comments to be turned
+   // on and off from a setting in the input file.
+   if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      cout << "******* SineLagCompensation::bypass_receive_lag_compensation():" << __LINE__ << endl
+           << " scenario-time:" << get_scenario_time() << endl
+           << "     data-time:" << lag_comp_data->get_time() << endl
+           << "            dt:" << dt << endl
+           << " adjusted-time:" << time << endl
+           << " BEFORE Bypassing Lag Compensation:" << endl
+           << "\t Name  lag_comp_data: '" << lag_comp_data->get_name()
+           << "', received update:" << ( name_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Time  lag_comp_data: " << lag_comp_data->get_time()
+           << ", received update:" << ( time_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Value lag_comp_data: " << lag_comp_data->get_value()
+           << ", received update:" << ( value_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t dvdt  lag_comp_data: " << lag_comp_data->get_derivative()
+           << ", received update:" << ( dvdt_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Phase lag_comp_data: " << lag_comp_data->get_phase()
+           << ", received update:" << ( phase_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Amp   lag_comp_data: " << lag_comp_data->get_amplitude()
+           << ", received update:" << ( amp_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Freq  lag_comp_data: " << lag_comp_data->get_frequency()
+           << ", received update:" << ( freq_attr->is_received() ? "Yes" : "No" ) << endl
+
+           << "\t Tol   lag_comp_data: " << lag_comp_data->get_tolerance()
+           << ", received update:" << ( tol_attr->is_received() ? "Yes" : "No" ) << endl;
+   }
+
+   // If the HLA time attribute has changed and is remotely owned (i.e. is
+   // coming from another federate) then override our simulation state with the
+   // incoming value. If we locally own the attribute then we do not want to
+   // override it's value. If we did not do this check then we would be
+   // overriding state of something we own and publish with whatever value
+   // happen to be in the local variable, which would cause data corruption of
+   // the state. We always need to do this check because ownership transfers
+   // could happen at any time or the data could be at a different rate.
+   // Because of ownership transfers and attributes being sent at different
+   // rates we need to check to see if we received data for each attribute.
+
+   // Bypass receive lag compensation by copying lag-comp data to sim-data.
+   if ( name_attr->is_received() ) {
+      sim_data->set_name( lag_comp_data->get_name() );
+   }
+   if ( time_attr->is_received() ) {
+      sim_data->set_time( lag_comp_data->get_time() );
+   }
+   if ( value_attr->is_received() ) {
+      sim_data->set_value( lag_comp_data->get_value() );
+   }
+   if ( dvdt_attr->is_received() ) {
+      sim_data->set_derivative( lag_comp_data->get_derivative() );
+   }
+   if ( phase_attr->is_received() ) {
+      sim_data->set_phase( lag_comp_data->get_phase() );
+   }
+   if ( freq_attr->is_received() ) {
+      sim_data->set_frequency( lag_comp_data->get_frequency() );
+   }
+   if ( amp_attr->is_received() ) {
+      sim_data->set_amplitude( lag_comp_data->get_amplitude() );
+   }
+   if ( tol_attr->is_received() ) {
+      sim_data->set_tolerance( lag_comp_data->get_tolerance() );
+   }
+
+   // Use the inherited debug-handler to allow debug comments to be turned
+   // on and off from a setting in the input file.
+   if ( DebugHandler::show( DEBUG_LEVEL_6_TRACE, DEBUG_SOURCE_LAG_COMPENSATION ) ) {
+      cout << "SineLagCompensation::bypass_receive_lag_compensation():" << __LINE__ << endl
+           << " AFTER BYPASSING LAG COMPENSATION:" << endl
+           << "\t Name  sim_data: '" << sim_data->get_name() << "'" << endl
+           << "\t Time  sim_data: " << sim_data->get_time() << endl
+           << "\t Value sim_data: " << sim_data->get_value() << endl
+           << "\t dvdt  sim_data: " << sim_data->get_derivative() << endl
+           << "\t Phase sim_data: " << sim_data->get_phase() << endl
+           << "\t Amp   sim_data: " << sim_data->get_amplitude() << endl
+           << "\t Freq  sim_data: " << sim_data->get_frequency() << endl
+           << "\t Tol   sim_data: " << sim_data->get_tolerance() << endl;
    }
 }

--- a/models/sine/src/SineOwnershipHandler.cpp
+++ b/models/sine/src/SineOwnershipHandler.cpp
@@ -44,6 +44,7 @@ using namespace TrickHLAModel;
  * @job_class{initialization}
  */
 SineOwnershipHandler::SineOwnershipHandler()
+   : TrickHLA::OwnershipHandler()
 {
    return;
 } // Default constructor.

--- a/models/sine/src/SineOwnershipHandler.cpp
+++ b/models/sine/src/SineOwnershipHandler.cpp
@@ -17,6 +17,7 @@ NASA, Johnson Space Center\n
 @tldh
 @trick_link_dependency{../source/TrickHLA/Object.cpp}
 @trick_link_dependency{../source/TrickHLA/OwnershipHandler.cpp}
+@trick_link_dependency{../source/TrickHLA/Types.cpp}
 @trick_link_dependency{sine/src/SineOwnershipHandler.cpp}
 
 @revs_title
@@ -32,6 +33,11 @@ NASA, Johnson Space Center\n
 #include <sstream>
 #include <stdlib.h>
 #include <string>
+
+// TrickHLA include files.
+#include "TrickHLA/Object.hh"
+#include "TrickHLA/OwnershipHandler.hh"
+#include "TrickHLA/Types.hh"
 
 // Model include files.
 #include "../include/SineOwnershipHandler.hh"

--- a/models/sine/src/SinePacking.cpp
+++ b/models/sine/src/SinePacking.cpp
@@ -58,7 +58,9 @@ using namespace TrickHLAModel;
  * @job_class{initialization}
  */
 SinePacking::SinePacking()
-   : sim_data( NULL ),
+   : SineData(),
+     TrickHLA::Packing(),
+     sim_data( NULL ),
      phase_deg( 0.0 ),
      pack_count( 0 ),
      initialized( false ),

--- a/models/sine/src/SinePacking.cpp
+++ b/models/sine/src/SinePacking.cpp
@@ -168,7 +168,7 @@ void SinePacking::pack()
    // Use the inherited debug-handler to allow debug comments to be turned
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_2_TRACE, DEBUG_SOURCE_PACKING ) ) {
-      string obj_name = ( object != NULL ) ? object->get_name_string() : "";
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
 
       cout << "SinePacking::pack():" << __LINE__ << endl
            << "\t Object-Name:'" << obj_name << "'" << endl
@@ -229,7 +229,7 @@ void SinePacking::pack()
          }
       }
 
-      string obj_name = ( object != NULL ) ? object->get_name_string() : "";
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
 
       cout << "SinePacking::pack():" << __LINE__ << " ADDITIONAL DEBUG:" << endl
            << "\t Object-Name:'" << obj_name << "'" << endl;
@@ -325,7 +325,7 @@ void SinePacking::unpack()
    // on and off from a setting in the input file.
    if ( DebugHandler::show( DEBUG_LEVEL_2_TRACE, DEBUG_SOURCE_PACKING ) ) {
 
-      string obj_name = ( object != NULL ) ? object->get_name_string() : "";
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
 
       cout << "SinePacking::unpack():" << __LINE__ << endl
            << "\t Object-Name:'" << obj_name << "'" << endl
@@ -375,7 +375,7 @@ void SinePacking::unpack()
          }
       }
 
-      string obj_name = ( object != NULL ) ? object->get_name_string() : "";
+      string obj_name = ( this->object != NULL ) ? this->object->get_name_string() : "";
 
       cout << "SinePacking::unpack():" << __LINE__ << " ADDITIONAL DEBUG:" << endl
            << "\t Object-Name:'" << obj_name << "'" << endl;

--- a/models/sine/src/SinePacking.cpp
+++ b/models/sine/src/SinePacking.cpp
@@ -120,6 +120,7 @@ void SinePacking::initialize_callback(
    // Get a reference to the TrickHL-AAttribute for all the FOM attributes
    // names. We do this here so that we only do the attribute lookup once
    // instead of looking it up every time the unpack function is called.
+   name_attr  = get_attribute_and_validate( "Name" );
    time_attr  = get_attribute_and_validate( "Time" );
    value_attr = get_attribute_and_validate( "Value" );
    dvdt_attr  = get_attribute_and_validate( "dvdt" );
@@ -127,7 +128,6 @@ void SinePacking::initialize_callback(
    freq_attr  = get_attribute_and_validate( "Frequency" );
    amp_attr   = get_attribute_and_validate( "Amplitude" );
    tol_attr   = get_attribute_and_validate( "Tolerance" );
-   name_attr  = get_attribute_and_validate( "Name" );
 }
 
 void SinePacking::pack()
@@ -145,6 +145,16 @@ void SinePacking::pack()
    // in the unpack() function, since we don't run the risk of corrupting our
    // state.
 
+   // Copy over the sim-data over to the packing data as a starting point.
+   this->set_name( sim_data->get_name() );
+   this->set_time( sim_data->get_time() );
+   this->set_value( sim_data->get_value() );
+   this->set_derivative( sim_data->get_derivative() );
+   this->set_phase( sim_data->get_phase() );
+   this->set_frequency( sim_data->get_frequency() );
+   this->set_amplitude( sim_data->get_amplitude() );
+   this->set_tolerance( sim_data->get_tolerance() );
+
    // For this example to show how to use the Packing API's, we will assume
    // that the phase shared between federates is in degrees so covert it from
    // radians to degrees.
@@ -159,43 +169,43 @@ void SinePacking::pack()
            << "\t Object-Name:'" << obj_name << "'" << endl
 
            << "\t sim_data->name:'" << sim_data->get_name()
-           << "', Send-as-HLA-Data:"
+           << "', Send-HLA-Data:"
            << ( ( name_attr->is_publish() && name_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->time:" << sim_data->get_time() << " seconds"
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( time_attr->is_publish() && time_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->value:" << sim_data->get_value()
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( value_attr->is_publish() && value_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->dvdt:" << sim_data->get_derivative()
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( dvdt_attr->is_publish() && dvdt_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->phase:" << sim_data->get_phase() << " radians"
            << " ==> packing-phase:" << phase_deg << " degrees"
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( phase_attr->is_publish() && phase_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->amp:" << sim_data->get_amplitude()
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( amp_attr->is_publish() && amp_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->freq:" << sim_data->get_frequency()
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( freq_attr->is_publish() && freq_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
            << "\t sim_data->tol:" << sim_data->get_tolerance()
-           << ", Send-as-HLA-Data:"
+           << ", Send-HLA-Data:"
            << ( ( tol_attr->is_publish() && tol_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl;
    }
@@ -275,6 +285,33 @@ void SinePacking::unpack()
    // corruption of the state. We always need to do this check because
    // ownership transfers could happen at any time or the data could be at a
    // different rate.
+
+   // Make sure to copy over the packing data over to the sim-data.
+   if ( name_attr->is_received() ) {
+      sim_data->set_name( this->get_name() );
+   }
+   if ( time_attr->is_received() ) {
+      sim_data->set_time( this->get_time() );
+   }
+   if ( value_attr->is_received() ) {
+      sim_data->set_value( this->get_value() );
+   }
+   if ( dvdt_attr->is_received() ) {
+      sim_data->set_derivative( this->get_derivative() );
+   }
+   if ( phase_attr->is_received() ) {
+      sim_data->set_phase( this->get_phase() );
+   }
+   if ( freq_attr->is_received() ) {
+      sim_data->set_frequency( this->get_frequency() );
+   }
+   if ( amp_attr->is_received() ) {
+      sim_data->set_amplitude( this->get_amplitude() );
+   }
+   if ( tol_attr->is_received() ) {
+      sim_data->set_tolerance( this->get_tolerance() );
+   }
+
    if ( phase_attr->is_received() ) {
       // For this example to show how to use the Packing API's, we will
       // assume that the phase shared between federates is in degrees so

--- a/models/sine/src/SinePacking.cpp
+++ b/models/sine/src/SinePacking.cpp
@@ -19,6 +19,7 @@ NASA, Johnson Space Center\n
 @trick_link_dependency{../source/TrickHLA/DebugHandler.cpp}
 @trick_link_dependency{../source/TrickHLA/Object.cpp}
 @trick_link_dependency{../source/TrickHLA/Types.cpp}
+@trick_link_dependency{sine/src/SineData.cpp}
 @trick_link_dependency{sine/src/SinePacking.cpp}
 
 @revs_title
@@ -31,6 +32,7 @@ NASA, Johnson Space Center\n
 
 // System include files.
 #include <algorithm>
+#include <iomanip>
 #include <iostream>
 #include <math.h>
 #include <stdlib.h>
@@ -48,6 +50,7 @@ NASA, Johnson Space Center\n
 #include "TrickHLA/Types.hh"
 
 // Model include files.
+#include "../include/SineData.hh"
 #include "../include/SinePacking.hh"
 
 using namespace std;
@@ -175,7 +178,7 @@ void SinePacking::pack()
            << ( ( name_attr->is_publish() && name_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
 
-           << "\t sim_data->time:" << sim_data->get_time() << " seconds"
+           << "\t sim_data->time:" << setprecision( 18 ) << sim_data->get_time() << " seconds"
            << ", Send-HLA-Data:"
            << ( ( time_attr->is_publish() && time_attr->is_locally_owned() ) ? "Yes" : "No" )
            << endl
@@ -331,7 +334,7 @@ void SinePacking::unpack()
            << "', Received-HLA-Data:"
            << ( name_attr->is_received() ? "Yes" : "No" ) << endl
 
-           << "\t sim_data->time:" << sim_data->get_time()
+           << "\t sim_data->time:" << setprecision( 18 ) << sim_data->get_time()
            << " seconds, Received-HLA-Data:"
            << ( time_attr->is_received() ? "Yes" : "No" ) << endl
 

--- a/models/sine/src/SinePacking.cpp
+++ b/models/sine/src/SinePacking.cpp
@@ -299,9 +299,6 @@ void SinePacking::unpack()
    if ( dvdt_attr->is_received() ) {
       sim_data->set_derivative( this->get_derivative() );
    }
-   if ( phase_attr->is_received() ) {
-      sim_data->set_phase( this->get_phase() );
-   }
    if ( freq_attr->is_received() ) {
       sim_data->set_frequency( this->get_frequency() );
    }

--- a/sims/TrickHLA/SIM_sine/Log_data/log_sine_states.py
+++ b/sims/TrickHLA/SIM_sine/Log_data/log_sine_states.py
@@ -60,17 +60,17 @@ def log_sine_states( sim_object_name, log_cycle ) :
    var = sim_object_name + ".sim_data.dvdt"
    dr_group.add_variable(var)
    
-   var = sim_object_name + ".lag_comp_data.value"
+   var = sim_object_name + ".lag_compensation.value"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.time"
+   var = sim_object_name + ".lag_compensation.time"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.phase"
+   var = sim_object_name + ".lag_compensation.phase"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.amp"
+   var = sim_object_name + ".lag_compensation.amp"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.freq"
+   var = sim_object_name + ".lag_compensation.freq"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.dvdt"
+   var = sim_object_name + ".lag_compensation.dvdt"
    dr_group.add_variable(var)
 
 

--- a/sims/TrickHLA/SIM_sine/RUN_a_side/input.py
+++ b/sims/TrickHLA/SIM_sine/RUN_a_side/input.py
@@ -140,20 +140,22 @@ THLA.manager.objects[0].FOM_name            = 'Test'
 THLA.manager.objects[0].name                = 'A-side-Federate.Test'
 THLA.manager.objects[0].create_HLA_instance = True
 THLA.manager.objects[0].packing             = A.packing
+THLA.manager.objects[0].lag_comp            = A.lag_compensation
+THLA.manager.objects[0].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[0].ownership           = A.ownership_handler
 THLA.manager.objects[0].deleted             = A.obj_deleted_callback
 THLA.manager.objects[0].attr_count          = 8
 THLA.manager.objects[0].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[0].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[0].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[0].attributes[0].trick_name      = 'A.sim_data.time'
+THLA.manager.objects[0].attributes[0].trick_name      = 'A.packing.time'
 THLA.manager.objects[0].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[0].publish         = True
 THLA.manager.objects[0].attributes[0].locally_owned   = True
 THLA.manager.objects[0].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[0].attributes[1].trick_name      = 'A.sim_data.value'
+THLA.manager.objects[0].attributes[1].trick_name      = 'A.packing.value'
 THLA.manager.objects[0].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[1].publish         = True
 THLA.manager.objects[0].attributes[1].subscribe       = True
@@ -161,7 +163,7 @@ THLA.manager.objects[0].attributes[1].locally_owned   = True
 THLA.manager.objects[0].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[0].attributes[2].trick_name      = 'A.sim_data.dvdt'
+THLA.manager.objects[0].attributes[2].trick_name      = 'A.packing.dvdt'
 THLA.manager.objects[0].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[2].publish         = True
 THLA.manager.objects[0].attributes[2].locally_owned   = True
@@ -175,28 +177,28 @@ THLA.manager.objects[0].attributes[3].locally_owned   = True
 THLA.manager.objects[0].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[0].attributes[4].trick_name      = 'A.sim_data.freq'
+THLA.manager.objects[0].attributes[4].trick_name      = 'A.packing.freq'
 THLA.manager.objects[0].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[4].publish         = True
 THLA.manager.objects[0].attributes[4].locally_owned   = True
 THLA.manager.objects[0].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[0].attributes[5].trick_name      = 'A.sim_data.amp'
+THLA.manager.objects[0].attributes[5].trick_name      = 'A.packing.amp'
 THLA.manager.objects[0].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[5].publish         = True
 THLA.manager.objects[0].attributes[5].locally_owned   = True
 THLA.manager.objects[0].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[0].attributes[6].trick_name      = 'A.sim_data.tol'
+THLA.manager.objects[0].attributes[6].trick_name      = 'A.packing.tol'
 THLA.manager.objects[0].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[6].publish         = True
 THLA.manager.objects[0].attributes[6].locally_owned   = True
 THLA.manager.objects[0].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[0].attributes[7].trick_name      = 'A.sim_data.name'
+THLA.manager.objects[0].attributes[7].trick_name      = 'A.packing.name'
 THLA.manager.objects[0].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[7].publish         = True
 THLA.manager.objects[0].attributes[7].locally_owned   = True
@@ -208,19 +210,21 @@ THLA.manager.objects[1].FOM_name            = 'Test'
 THLA.manager.objects[1].name                = 'P-side-Federate.Test'
 THLA.manager.objects[1].create_HLA_instance = False
 THLA.manager.objects[1].packing             = P.packing
+THLA.manager.objects[1].lag_comp            = P.lag_compensation
+THLA.manager.objects[1].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[1].deleted             = P.obj_deleted_callback
 THLA.manager.objects[1].attr_count          = 8
 THLA.manager.objects[1].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[1].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[1].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[1].attributes[0].trick_name      = 'P.sim_data.time'
+THLA.manager.objects[1].attributes[0].trick_name      = 'P.packing.time'
 THLA.manager.objects[1].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[0].subscribe       = True
 THLA.manager.objects[1].attributes[0].locally_owned   = False
 THLA.manager.objects[1].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[1].attributes[1].trick_name      = 'P.sim_data.value'
+THLA.manager.objects[1].attributes[1].trick_name      = 'P.packing.value'
 THLA.manager.objects[1].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[1].publish         = True
 THLA.manager.objects[1].attributes[1].subscribe       = True
@@ -228,7 +232,7 @@ THLA.manager.objects[1].attributes[1].locally_owned   = False
 THLA.manager.objects[1].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[1].attributes[2].trick_name      = 'P.sim_data.dvdt'
+THLA.manager.objects[1].attributes[2].trick_name      = 'P.packing.dvdt'
 THLA.manager.objects[1].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[2].publish         = True
 THLA.manager.objects[1].attributes[2].subscribe       = True
@@ -243,28 +247,28 @@ THLA.manager.objects[1].attributes[3].locally_owned   = False
 THLA.manager.objects[1].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[1].attributes[4].trick_name      = 'P.sim_data.freq'
+THLA.manager.objects[1].attributes[4].trick_name      = 'P.packing.freq'
 THLA.manager.objects[1].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[4].subscribe       = True
 THLA.manager.objects[1].attributes[4].locally_owned   = False
 THLA.manager.objects[1].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[1].attributes[5].trick_name      = 'P.sim_data.amp'
+THLA.manager.objects[1].attributes[5].trick_name      = 'P.packing.amp'
 THLA.manager.objects[1].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[5].subscribe       = True
 THLA.manager.objects[1].attributes[5].locally_owned   = False
 THLA.manager.objects[1].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[1].attributes[6].trick_name      = 'P.sim_data.tol'
+THLA.manager.objects[1].attributes[6].trick_name      = 'P.packing.tol'
 THLA.manager.objects[1].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[6].subscribe       = True
 THLA.manager.objects[1].attributes[6].locally_owned   = False
 THLA.manager.objects[1].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[1].attributes[7].trick_name      = 'P.sim_data.name'
+THLA.manager.objects[1].attributes[7].trick_name      = 'P.packing.name'
 THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[7].subscribe       = True
 THLA.manager.objects[1].attributes[7].locally_owned   = False

--- a/sims/TrickHLA/SIM_sine/RUN_a_side/input.py
+++ b/sims/TrickHLA/SIM_sine/RUN_a_side/input.py
@@ -5,7 +5,7 @@
 trick.exec_set_trap_sigfpe(True)
 #trick.checkpoint_pre_init(1)
 trick.checkpoint_post_init(1)
-#trick.add_read(0.0 , '''trick.checkpoint('chkpnt_point')''')
+#trick.add_read(0.0 , '''trick.checkpoint('checkpoint')''')
 
 # Realtime setup
 exec(open( "Modified_data/trick/realtime.py" ).read())

--- a/sims/TrickHLA/SIM_sine/RUN_p_side/input.py
+++ b/sims/TrickHLA/SIM_sine/RUN_p_side/input.py
@@ -6,7 +6,7 @@
 trick.exec_set_trap_sigfpe(True)
 #trick.checkpoint_pre_init(1)
 trick.checkpoint_post_init(1)
-#trick.add_read(0.0 , '''trick.checkpoint('chkpnt_point')''')
+#trick.add_read(0.0 , '''trick.checkpoint('checkpoint')''')
 
 # NOTE: You must set this to be the same as the master federate's frame for IMSim freezing
 trick.exec_set_software_frame(0.25)

--- a/sims/TrickHLA/SIM_sine/RUN_p_side/input.py
+++ b/sims/TrickHLA/SIM_sine/RUN_p_side/input.py
@@ -146,12 +146,14 @@ THLA.manager.objects[0].FOM_name            = 'Test'
 THLA.manager.objects[0].name                = 'A-side-Federate.Test'
 THLA.manager.objects[0].create_HLA_instance = False
 THLA.manager.objects[0].packing             = A.packing
+THLA.manager.objects[0].lag_comp            = A.lag_compensation
+THLA.manager.objects[0].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[0].deleted             = A.obj_deleted_callback
 THLA.manager.objects[0].attr_count          = 8
 THLA.manager.objects[0].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[0].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[0].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[0].attributes[0].trick_name      = 'A.sim_data.time'
+THLA.manager.objects[0].attributes[0].trick_name      = 'A.packing.time'
 THLA.manager.objects[0].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[0].publish         = True
 THLA.manager.objects[0].attributes[0].subscribe       = True
@@ -159,7 +161,7 @@ THLA.manager.objects[0].attributes[0].locally_owned   = False
 THLA.manager.objects[0].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[0].attributes[1].trick_name      = 'A.sim_data.value'
+THLA.manager.objects[0].attributes[1].trick_name      = 'A.packing.value'
 THLA.manager.objects[0].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[1].publish         = True
 THLA.manager.objects[0].attributes[1].subscribe       = True
@@ -167,7 +169,7 @@ THLA.manager.objects[0].attributes[1].locally_owned   = False
 THLA.manager.objects[0].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[0].attributes[2].trick_name      = 'A.sim_data.dvdt'
+THLA.manager.objects[0].attributes[2].trick_name      = 'A.packing.dvdt'
 THLA.manager.objects[0].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[2].publish         = True
 THLA.manager.objects[0].attributes[2].subscribe       = True
@@ -183,7 +185,7 @@ THLA.manager.objects[0].attributes[3].locally_owned   = False
 THLA.manager.objects[0].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[0].attributes[4].trick_name      = 'A.sim_data.freq'
+THLA.manager.objects[0].attributes[4].trick_name      = 'A.packing.freq'
 THLA.manager.objects[0].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[4].publish         = True
 THLA.manager.objects[0].attributes[4].subscribe       = True
@@ -191,7 +193,7 @@ THLA.manager.objects[0].attributes[4].locally_owned   = False
 THLA.manager.objects[0].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[0].attributes[5].trick_name      = 'A.sim_data.amp'
+THLA.manager.objects[0].attributes[5].trick_name      = 'A.packing.amp'
 THLA.manager.objects[0].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[5].publish         = True
 THLA.manager.objects[0].attributes[5].subscribe       = True
@@ -199,7 +201,7 @@ THLA.manager.objects[0].attributes[5].locally_owned   = False
 THLA.manager.objects[0].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[0].attributes[6].trick_name      = 'A.sim_data.tol'
+THLA.manager.objects[0].attributes[6].trick_name      = 'A.packing.tol'
 THLA.manager.objects[0].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[6].publish         = True
 THLA.manager.objects[0].attributes[6].subscribe       = True
@@ -207,7 +209,7 @@ THLA.manager.objects[0].attributes[6].locally_owned   = False
 THLA.manager.objects[0].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[0].attributes[7].trick_name      = 'A.sim_data.name'
+THLA.manager.objects[0].attributes[7].trick_name      = 'A.packing.name'
 THLA.manager.objects[0].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[7].publish         = True
 THLA.manager.objects[0].attributes[7].subscribe       = True
@@ -221,19 +223,21 @@ THLA.manager.objects[1].FOM_name            = 'Test'
 THLA.manager.objects[1].name                = 'P-side-Federate.Test'
 THLA.manager.objects[1].create_HLA_instance = True
 THLA.manager.objects[1].packing             = P.packing
+THLA.manager.objects[1].lag_comp            = P.lag_compensation
+THLA.manager.objects[1].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[1].deleted             = P.obj_deleted_callback
 THLA.manager.objects[1].attr_count          = 8
 THLA.manager.objects[1].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[1].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[1].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[1].attributes[0].trick_name      = 'P.sim_data.time'
+THLA.manager.objects[1].attributes[0].trick_name      = 'P.packing.time'
 THLA.manager.objects[1].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[0].publish         = True
 THLA.manager.objects[1].attributes[0].locally_owned   = True
 THLA.manager.objects[1].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[1].attributes[1].trick_name      = 'P.sim_data.value'
+THLA.manager.objects[1].attributes[1].trick_name      = 'P.packing.value'
 THLA.manager.objects[1].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[1].publish         = True
 THLA.manager.objects[1].attributes[1].subscribe       = True
@@ -241,7 +245,7 @@ THLA.manager.objects[1].attributes[1].locally_owned   = True
 THLA.manager.objects[1].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[1].attributes[2].trick_name      = 'P.sim_data.dvdt'
+THLA.manager.objects[1].attributes[2].trick_name      = 'P.packing.dvdt'
 THLA.manager.objects[1].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[2].publish         = True
 THLA.manager.objects[1].attributes[2].locally_owned   = True
@@ -255,28 +259,28 @@ THLA.manager.objects[1].attributes[3].locally_owned   = True
 THLA.manager.objects[1].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[1].attributes[4].trick_name      = 'P.sim_data.freq'
+THLA.manager.objects[1].attributes[4].trick_name      = 'P.packing.freq'
 THLA.manager.objects[1].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[4].publish         = True
 THLA.manager.objects[1].attributes[4].locally_owned   = True
 THLA.manager.objects[1].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[1].attributes[5].trick_name      = 'P.sim_data.amp'
+THLA.manager.objects[1].attributes[5].trick_name      = 'P.packing.amp'
 THLA.manager.objects[1].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[5].publish         = True
 THLA.manager.objects[1].attributes[5].locally_owned   = True
 THLA.manager.objects[1].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[1].attributes[6].trick_name      = 'P.sim_data.tol'
+THLA.manager.objects[1].attributes[6].trick_name      = 'P.packing.tol'
 THLA.manager.objects[1].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[6].publish         = True
 THLA.manager.objects[1].attributes[6].locally_owned   = True
 THLA.manager.objects[1].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[1].attributes[7].trick_name      = 'P.sim_data.name'
+THLA.manager.objects[1].attributes[7].trick_name      = 'P.packing.name'
 THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[7].publish         = True
 THLA.manager.objects[1].attributes[7].locally_owned   = True

--- a/sims/TrickHLA/SIM_sine/S_define
+++ b/sims/TrickHLA/SIM_sine/S_define
@@ -45,7 +45,6 @@ class AnalyticSineSimObj : public Trick::SimObject {
  public:
    TrickHLAModel::SineData truth_data;
    TrickHLAModel::SineData sim_data;
-   TrickHLAModel::SineData lag_comp_data;
 
    TrickHLAModel::SineOwnershipHandler   ownership_handler;
 
@@ -58,9 +57,9 @@ class AnalyticSineSimObj : public Trick::SimObject {
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
 
    AnalyticSineSimObj() {
-      P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
+      P50 ("initialization") lag_compensation.initialize( &sim_data );
 
-      P50 ("initialization") packing.initialize( &lag_comp_data );
+      P50 ("initialization") packing.initialize( &lag_compensation );
 
       (DYN_RATE, "scheduled") truth_data.compute_value( THLA.execution_control.get_scenario_time() );
       (DYN_RATE, "scheduled") truth_data.compute_derivative( THLA.execution_control.get_scenario_time() );
@@ -87,7 +86,6 @@ class PropagatedSineSimObj : public Trick::SimObject {
  public:
    TrickHLAModel::SineData truth_data;
    TrickHLAModel::SineData sim_data;
-   TrickHLAModel::SineData lag_comp_data;
 
    TrickHLAModel::SinePacking            packing;
 
@@ -100,9 +98,9 @@ class PropagatedSineSimObj : public Trick::SimObject {
    PropagatedSineSimObj() {
       // Note: Make sure to initialize the data before it gets sent in
       // the THLA_INIT simulation object.
-      P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
+      P50 ("initialization") lag_compensation.initialize( &sim_data );
 
-      P50 ("initialization") packing.initialize( &lag_comp_data );
+      P50 ("initialization") packing.initialize( &lag_compensation );
 
       /*
        * -- Propagate the true sine state.

--- a/sims/TrickHLA/SIM_sine/S_define
+++ b/sims/TrickHLA/SIM_sine/S_define
@@ -57,6 +57,11 @@ class AnalyticSineSimObj : public Trick::SimObject {
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
 
    AnalyticSineSimObj() {
+      // Note: Make sure to initialize the data before it gets sent in
+      // the THLA_INIT simulation object.
+      //
+      // TrickHLA API data flow, sending data:   sim-data --> lag-comp-data --> packing-data
+      // TrickHLA API data flow, receiving data: packing-data --> lag-comp-data --> sim-data
       P50 ("initialization") lag_compensation.initialize( &sim_data );
 
       P50 ("initialization") packing.initialize( &lag_compensation );
@@ -98,6 +103,9 @@ class PropagatedSineSimObj : public Trick::SimObject {
    PropagatedSineSimObj() {
       // Note: Make sure to initialize the data before it gets sent in
       // the THLA_INIT simulation object.
+      //
+      // TrickHLA API data flow, sending data:   sim-data --> lag-comp-data --> packing-data
+      // TrickHLA API data flow, receiving data: packing-data --> lag-comp-data --> sim-data
       P50 ("initialization") lag_compensation.initialize( &sim_data );
 
       P50 ("initialization") packing.initialize( &lag_compensation );

--- a/sims/TrickHLA/SIM_sine/S_define
+++ b/sims/TrickHLA/SIM_sine/S_define
@@ -58,9 +58,9 @@ class AnalyticSineSimObj : public Trick::SimObject {
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
 
    AnalyticSineSimObj() {
-      P50 ("initialization") packing.initialize( &sim_data );
-
       P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
+
+      P50 ("initialization") packing.initialize( &lag_comp_data );
 
       (DYN_RATE, "scheduled") truth_data.compute_value( THLA.execution_control.get_scenario_time() );
       (DYN_RATE, "scheduled") truth_data.compute_derivative( THLA.execution_control.get_scenario_time() );
@@ -100,9 +100,9 @@ class PropagatedSineSimObj : public Trick::SimObject {
    PropagatedSineSimObj() {
       // Note: Make sure to initialize the data before it gets sent in
       // the THLA_INIT simulation object.
-      P50 ("initialization") packing.initialize( &sim_data );
-
       P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
+
+      P50 ("initialization") packing.initialize( &lag_comp_data );
 
       /*
        * -- Propagate the true sine state.

--- a/sims/TrickHLA/SIM_sine_threads/Log_data/log_sine_states.py
+++ b/sims/TrickHLA/SIM_sine_threads/Log_data/log_sine_states.py
@@ -60,17 +60,17 @@ def log_sine_states( sim_object_name, log_cycle ) :
    var = sim_object_name + ".sim_data.dvdt"
    dr_group.add_variable(var)
    
-   var = sim_object_name + ".lag_comp_data.value"
+   var = sim_object_name + ".lag_compensation.value"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.time"
+   var = sim_object_name + ".lag_compensation.time"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.phase"
+   var = sim_object_name + ".lag_compensation.phase"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.amp"
+   var = sim_object_name + ".lag_compensation.amp"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.freq"
+   var = sim_object_name + ".lag_compensation.freq"
    dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.dvdt"
+   var = sim_object_name + ".lag_compensation.dvdt"
    dr_group.add_variable(var)
 
 

--- a/sims/TrickHLA/SIM_sine_threads/RUN_a_side/input.py
+++ b/sims/TrickHLA/SIM_sine_threads/RUN_a_side/input.py
@@ -5,7 +5,7 @@
 trick.exec_set_trap_sigfpe(True)
 #trick.checkpoint_pre_init(1)
 trick.checkpoint_post_init(1)
-#trick.add_read(0.0 , '''trick.checkpoint('chkpnt_point')''')
+#trick.add_read(0.0 , '''trick.checkpoint('checkpoint')''')
 
 # Realtime setup
 exec(open( "Modified_data/trick/realtime.py" ).read())
@@ -160,20 +160,22 @@ THLA.manager.objects[0].name                = 'A-side-Federate.Test'
 THLA.manager.objects[0].create_HLA_instance = True
 THLA.manager.objects[0].thread_ids          = "1"
 THLA.manager.objects[0].packing             = A.packing
-THLA.manager.objects[0].ownership           = A.ownership_handler
+THLA.manager.objects[0].lag_comp            = A.lag_compensation
+THLA.manager.objects[0].lag_comp_type       = trick.LAG_COMPENSATION_NONE
+#THLA.manager.objects[0].ownership           = A.ownership_handler
 THLA.manager.objects[0].deleted             = A.obj_deleted_callback
 THLA.manager.objects[0].attr_count          = 8
 THLA.manager.objects[0].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[0].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[0].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[0].attributes[0].trick_name      = 'A.sim_data.time'
+THLA.manager.objects[0].attributes[0].trick_name      = 'A.packing.time'
 THLA.manager.objects[0].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[0].publish         = True
 THLA.manager.objects[0].attributes[0].locally_owned   = True
 THLA.manager.objects[0].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[0].attributes[1].trick_name      = 'A.sim_data.value'
+THLA.manager.objects[0].attributes[1].trick_name      = 'A.packing.value'
 THLA.manager.objects[0].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[1].publish         = True
 THLA.manager.objects[0].attributes[1].subscribe       = True
@@ -181,7 +183,7 @@ THLA.manager.objects[0].attributes[1].locally_owned   = True
 THLA.manager.objects[0].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[0].attributes[2].trick_name      = 'A.sim_data.dvdt'
+THLA.manager.objects[0].attributes[2].trick_name      = 'A.packing.dvdt'
 THLA.manager.objects[0].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[2].publish         = True
 THLA.manager.objects[0].attributes[2].locally_owned   = True
@@ -195,28 +197,28 @@ THLA.manager.objects[0].attributes[3].locally_owned   = True
 THLA.manager.objects[0].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[0].attributes[4].trick_name      = 'A.sim_data.freq'
+THLA.manager.objects[0].attributes[4].trick_name      = 'A.packing.freq'
 THLA.manager.objects[0].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[4].publish         = True
 THLA.manager.objects[0].attributes[4].locally_owned   = True
 THLA.manager.objects[0].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[0].attributes[5].trick_name      = 'A.sim_data.amp'
+THLA.manager.objects[0].attributes[5].trick_name      = 'A.packing.amp'
 THLA.manager.objects[0].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[5].publish         = True
 THLA.manager.objects[0].attributes[5].locally_owned   = True
 THLA.manager.objects[0].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[0].attributes[6].trick_name      = 'A.sim_data.tol'
+THLA.manager.objects[0].attributes[6].trick_name      = 'A.packing.tol'
 THLA.manager.objects[0].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[6].publish         = True
 THLA.manager.objects[0].attributes[6].locally_owned   = True
 THLA.manager.objects[0].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[0].attributes[7].trick_name      = 'A.sim_data.name'
+THLA.manager.objects[0].attributes[7].trick_name      = 'A.packing.name'
 THLA.manager.objects[0].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[7].publish         = True
 THLA.manager.objects[0].attributes[7].locally_owned   = True
@@ -229,19 +231,21 @@ THLA.manager.objects[1].name                = 'P-side-Federate.Test'
 THLA.manager.objects[1].create_HLA_instance = False
 THLA.manager.objects[1].thread_ids          = "2"
 THLA.manager.objects[1].packing             = P.packing
+THLA.manager.objects[1].lag_comp            = P.lag_compensation
+THLA.manager.objects[1].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[1].deleted             = P.obj_deleted_callback
 THLA.manager.objects[1].attr_count          = 8
 THLA.manager.objects[1].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[1].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[1].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[1].attributes[0].trick_name      = 'P.sim_data.time'
+THLA.manager.objects[1].attributes[0].trick_name      = 'P.packing.time'
 THLA.manager.objects[1].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[0].subscribe       = True
 THLA.manager.objects[1].attributes[0].locally_owned   = False
 THLA.manager.objects[1].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[1].attributes[1].trick_name      = 'P.sim_data.value'
+THLA.manager.objects[1].attributes[1].trick_name      = 'P.packing.value'
 THLA.manager.objects[1].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[1].publish         = True
 THLA.manager.objects[1].attributes[1].subscribe       = True
@@ -249,7 +253,7 @@ THLA.manager.objects[1].attributes[1].locally_owned   = False
 THLA.manager.objects[1].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[1].attributes[2].trick_name      = 'P.sim_data.dvdt'
+THLA.manager.objects[1].attributes[2].trick_name      = 'P.packing.dvdt'
 THLA.manager.objects[1].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[2].publish         = True
 THLA.manager.objects[1].attributes[2].subscribe       = True
@@ -264,28 +268,28 @@ THLA.manager.objects[1].attributes[3].locally_owned   = False
 THLA.manager.objects[1].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[1].attributes[4].trick_name      = 'P.sim_data.freq'
+THLA.manager.objects[1].attributes[4].trick_name      = 'P.packing.freq'
 THLA.manager.objects[1].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[4].subscribe       = True
 THLA.manager.objects[1].attributes[4].locally_owned   = False
 THLA.manager.objects[1].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[1].attributes[5].trick_name      = 'P.sim_data.amp'
+THLA.manager.objects[1].attributes[5].trick_name      = 'P.packing.amp'
 THLA.manager.objects[1].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[5].subscribe       = True
 THLA.manager.objects[1].attributes[5].locally_owned   = False
 THLA.manager.objects[1].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[1].attributes[6].trick_name      = 'P.sim_data.tol'
+THLA.manager.objects[1].attributes[6].trick_name      = 'P.packing.tol'
 THLA.manager.objects[1].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[6].subscribe       = True
 THLA.manager.objects[1].attributes[6].locally_owned   = False
 THLA.manager.objects[1].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[1].attributes[7].trick_name      = 'P.sim_data.name'
+THLA.manager.objects[1].attributes[7].trick_name      = 'P.packing.name'
 THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[7].subscribe       = True
 THLA.manager.objects[1].attributes[7].locally_owned   = False

--- a/sims/TrickHLA/SIM_sine_threads/RUN_p_side/input.py
+++ b/sims/TrickHLA/SIM_sine_threads/RUN_p_side/input.py
@@ -5,7 +5,7 @@
 trick.exec_set_trap_sigfpe(True)
 #trick.checkpoint_pre_init(1)
 trick.checkpoint_post_init(1)
-#trick.add_read(0.0 , '''trick.checkpoint('chkpnt_point')''')
+#trick.add_read(0.0 , '''trick.checkpoint('checkpoint')''')
 
 # NOTE: You must set this to be the same as the master federate's frame for IMSim freezing
 trick.exec_set_software_frame(0.25)
@@ -165,12 +165,14 @@ THLA.manager.objects[0].name                = 'A-side-Federate.Test'
 THLA.manager.objects[0].create_HLA_instance = False
 THLA.manager.objects[0].thread_ids          = "1"
 THLA.manager.objects[0].packing             = A.packing
+THLA.manager.objects[0].lag_comp            = A.lag_compensation
+THLA.manager.objects[0].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[0].deleted             = A.obj_deleted_callback
 THLA.manager.objects[0].attr_count          = 8
 THLA.manager.objects[0].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[0].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[0].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[0].attributes[0].trick_name      = 'A.sim_data.time'
+THLA.manager.objects[0].attributes[0].trick_name      = 'A.packing.time'
 THLA.manager.objects[0].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[0].publish         = True
 THLA.manager.objects[0].attributes[0].subscribe       = True
@@ -178,7 +180,7 @@ THLA.manager.objects[0].attributes[0].locally_owned   = False
 THLA.manager.objects[0].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[0].attributes[1].trick_name      = 'A.sim_data.value'
+THLA.manager.objects[0].attributes[1].trick_name      = 'A.packing.value'
 THLA.manager.objects[0].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[1].publish         = True
 THLA.manager.objects[0].attributes[1].subscribe       = True
@@ -186,7 +188,7 @@ THLA.manager.objects[0].attributes[1].locally_owned   = False
 THLA.manager.objects[0].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[0].attributes[2].trick_name      = 'A.sim_data.dvdt'
+THLA.manager.objects[0].attributes[2].trick_name      = 'A.packing.dvdt'
 THLA.manager.objects[0].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[2].publish         = True
 THLA.manager.objects[0].attributes[2].subscribe       = True
@@ -202,7 +204,7 @@ THLA.manager.objects[0].attributes[3].locally_owned   = False
 THLA.manager.objects[0].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[0].attributes[4].trick_name      = 'A.sim_data.freq'
+THLA.manager.objects[0].attributes[4].trick_name      = 'A.packing.freq'
 THLA.manager.objects[0].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[4].publish         = True
 THLA.manager.objects[0].attributes[4].subscribe       = True
@@ -210,7 +212,7 @@ THLA.manager.objects[0].attributes[4].locally_owned   = False
 THLA.manager.objects[0].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[0].attributes[5].trick_name      = 'A.sim_data.amp'
+THLA.manager.objects[0].attributes[5].trick_name      = 'A.packing.amp'
 THLA.manager.objects[0].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[5].publish         = True
 THLA.manager.objects[0].attributes[5].subscribe       = True
@@ -218,7 +220,7 @@ THLA.manager.objects[0].attributes[5].locally_owned   = False
 THLA.manager.objects[0].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[0].attributes[6].trick_name      = 'A.sim_data.tol'
+THLA.manager.objects[0].attributes[6].trick_name      = 'A.packing.tol'
 THLA.manager.objects[0].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[6].publish         = True
 THLA.manager.objects[0].attributes[6].subscribe       = True
@@ -226,7 +228,7 @@ THLA.manager.objects[0].attributes[6].locally_owned   = False
 THLA.manager.objects[0].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[0].attributes[7].trick_name      = 'A.sim_data.name'
+THLA.manager.objects[0].attributes[7].trick_name      = 'A.packing.name'
 THLA.manager.objects[0].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[0].attributes[7].publish         = True
 THLA.manager.objects[0].attributes[7].subscribe       = True
@@ -241,19 +243,21 @@ THLA.manager.objects[1].name                = 'P-side-Federate.Test'
 THLA.manager.objects[1].create_HLA_instance = True
 THLA.manager.objects[1].thread_ids          = "2"
 THLA.manager.objects[1].packing             = P.packing
+THLA.manager.objects[1].lag_comp            = P.lag_compensation
+THLA.manager.objects[1].lag_comp_type       = trick.LAG_COMPENSATION_NONE
 THLA.manager.objects[1].deleted             = P.obj_deleted_callback
 THLA.manager.objects[1].attr_count          = 8
 THLA.manager.objects[1].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[1].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[1].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[1].attributes[0].trick_name      = 'P.sim_data.time'
+THLA.manager.objects[1].attributes[0].trick_name      = 'P.packing.time'
 THLA.manager.objects[1].attributes[0].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[0].publish         = True
 THLA.manager.objects[1].attributes[0].locally_owned   = True
 THLA.manager.objects[1].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[1].attributes[1].trick_name      = 'P.sim_data.value'
+THLA.manager.objects[1].attributes[1].trick_name      = 'P.packing.value'
 THLA.manager.objects[1].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[1].publish         = True
 THLA.manager.objects[1].attributes[1].subscribe       = True
@@ -261,7 +265,7 @@ THLA.manager.objects[1].attributes[1].locally_owned   = True
 THLA.manager.objects[1].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[1].attributes[2].trick_name      = 'P.sim_data.dvdt'
+THLA.manager.objects[1].attributes[2].trick_name      = 'P.packing.dvdt'
 THLA.manager.objects[1].attributes[2].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[2].publish         = True
 THLA.manager.objects[1].attributes[2].locally_owned   = True
@@ -275,28 +279,28 @@ THLA.manager.objects[1].attributes[3].locally_owned   = True
 THLA.manager.objects[1].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[1].attributes[4].trick_name      = 'P.sim_data.freq'
+THLA.manager.objects[1].attributes[4].trick_name      = 'P.packing.freq'
 THLA.manager.objects[1].attributes[4].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[4].publish         = True
 THLA.manager.objects[1].attributes[4].locally_owned   = True
 THLA.manager.objects[1].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[1].attributes[5].trick_name      = 'P.sim_data.amp'
+THLA.manager.objects[1].attributes[5].trick_name      = 'P.packing.amp'
 THLA.manager.objects[1].attributes[5].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[5].publish         = True
 THLA.manager.objects[1].attributes[5].locally_owned   = True
 THLA.manager.objects[1].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[1].attributes[6].trick_name      = 'P.sim_data.tol'
+THLA.manager.objects[1].attributes[6].trick_name      = 'P.packing.tol'
 THLA.manager.objects[1].attributes[6].config          = trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[6].publish         = True
 THLA.manager.objects[1].attributes[6].locally_owned   = True
 THLA.manager.objects[1].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[1].attributes[7].trick_name      = 'P.sim_data.name'
+THLA.manager.objects[1].attributes[7].trick_name      = 'P.packing.name'
 THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
 THLA.manager.objects[1].attributes[7].publish         = True
 THLA.manager.objects[1].attributes[7].locally_owned   = True

--- a/sims/TrickHLA/SIM_sine_threads/S_define
+++ b/sims/TrickHLA/SIM_sine_threads/S_define
@@ -50,7 +50,6 @@ class AnalyticSineSimObj : public Trick::SimObject {
  public:
    TrickHLAModel::SineData truth_data;
    TrickHLAModel::SineData sim_data;
-   TrickHLAModel::SineData lag_comp_data;
 
    TrickHLAModel::SineOwnershipHandler   ownership_handler;
 
@@ -63,9 +62,9 @@ class AnalyticSineSimObj : public Trick::SimObject {
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
 
    AnalyticSineSimObj() {
-      P50 ("initialization") packing.initialize( &sim_data );
+      P50 ("initialization") lag_compensation.initialize( &sim_data );
 
-      P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
+      P50 ("initialization") packing.initialize( &lag_compensation );
 
       C1 (DYN_RATE, "scheduled") truth_data.compute_value( THLA.execution_control.get_scenario_time() );
       C1 (DYN_RATE, "scheduled") truth_data.compute_derivative( THLA.execution_control.get_scenario_time() );
@@ -92,7 +91,6 @@ class PropagatedSineSimObj : public THLAThreadSimObject {
  public:
    TrickHLAModel::SineData truth_data;
    TrickHLAModel::SineData sim_data;
-   TrickHLAModel::SineData lag_comp_data;
 
    TrickHLAModel::SinePacking            packing;
 
@@ -111,9 +109,9 @@ class PropagatedSineSimObj : public THLAThreadSimObject {
    {
       // Note: Make sure to initialize the data before it gets sent in
       // the THLA_INIT simulation object.
-      P50 ("initialization") packing.initialize( &sim_data );
+      P50 ("initialization") lag_compensation.initialize( &sim_data );
 
-      P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
+      P50 ("initialization") packing.initialize( &lag_compensation );
 
       /*
        * -- Propagate the true sine state.

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/Log_data/log_sine_states.py
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/Log_data/log_sine_states.py
@@ -59,19 +59,6 @@ def log_sine_states( sim_object_name, log_cycle ) :
    dr_group.add_variable(var)
    var = sim_object_name + ".sim_data.dvdt"
    dr_group.add_variable(var)
-   
-   var = sim_object_name + ".lag_comp_data.value"
-   dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.time"
-   dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.phase"
-   dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.amp"
-   dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.freq"
-   dr_group.add_variable(var)
-   var = sim_object_name + ".lag_comp_data.dvdt"
-   dr_group.add_variable(var)
 
 
    #########################################################

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_a_side/input.py
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_a_side/input.py
@@ -5,7 +5,7 @@
 trick.exec_set_trap_sigfpe(True)
 #trick.checkpoint_pre_init(1)
 trick.checkpoint_post_init(1)
-#trick.add_read(0.0 , '''trick.checkpoint('chkpnt_point')''')
+#trick.add_read(0.0 , '''trick.checkpoint('checkpoint')''')
 
 # Realtime setup
 exec(open( "Modified_data/trick/realtime.py" ).read())
@@ -145,20 +145,19 @@ THLA.manager.objects[0].FOM_name            = 'Test'
 THLA.manager.objects[0].name                = 'A-side-Federate.Test'
 THLA.manager.objects[0].create_HLA_instance = True
 THLA.manager.objects[0].packing             = A.packing
-#THLA.manager.objects[0].ownership           = A.ownership_handler
 THLA.manager.objects[0].deleted             = A.obj_deleted_callback
 THLA.manager.objects[0].attr_count          = 8
 THLA.manager.objects[0].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[0].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[0].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[0].attributes[0].trick_name      = 'A.sim_data.time'
+THLA.manager.objects[0].attributes[0].trick_name      = 'A.packing.time'
 THLA.manager.objects[0].attributes[0].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[0].publish         = True
 THLA.manager.objects[0].attributes[0].locally_owned   = True
 THLA.manager.objects[0].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[0].attributes[1].trick_name      = 'A.sim_data.value'
+THLA.manager.objects[0].attributes[1].trick_name      = 'A.packing.value'
 THLA.manager.objects[0].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[1].publish         = True
 THLA.manager.objects[0].attributes[1].subscribe       = True
@@ -166,7 +165,7 @@ THLA.manager.objects[0].attributes[1].locally_owned   = True
 THLA.manager.objects[0].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[0].attributes[2].trick_name      = 'A.sim_data.dvdt'
+THLA.manager.objects[0].attributes[2].trick_name      = 'A.packing.dvdt'
 THLA.manager.objects[0].attributes[2].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[2].publish         = True
 THLA.manager.objects[0].attributes[2].locally_owned   = True
@@ -180,28 +179,28 @@ THLA.manager.objects[0].attributes[3].locally_owned   = True
 THLA.manager.objects[0].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[0].attributes[4].trick_name      = 'A.sim_data.freq'
+THLA.manager.objects[0].attributes[4].trick_name      = 'A.packing.freq'
 THLA.manager.objects[0].attributes[4].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[4].publish         = True
 THLA.manager.objects[0].attributes[4].locally_owned   = True
 THLA.manager.objects[0].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[0].attributes[5].trick_name      = 'A.sim_data.amp'
+THLA.manager.objects[0].attributes[5].trick_name      = 'A.packing.amp'
 THLA.manager.objects[0].attributes[5].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[5].publish         = True
 THLA.manager.objects[0].attributes[5].locally_owned   = True
 THLA.manager.objects[0].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[0].attributes[6].trick_name      = 'A.sim_data.tol'
+THLA.manager.objects[0].attributes[6].trick_name      = 'A.packing.tol'
 THLA.manager.objects[0].attributes[6].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[6].publish         = True
 THLA.manager.objects[0].attributes[6].locally_owned   = True
 THLA.manager.objects[0].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[0].attributes[7].trick_name      = 'A.sim_data.name'
+THLA.manager.objects[0].attributes[7].trick_name      = 'A.packing.name'
 THLA.manager.objects[0].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[7].publish         = True
 THLA.manager.objects[0].attributes[7].locally_owned   = True
@@ -218,14 +217,14 @@ THLA.manager.objects[1].attr_count          = 8
 THLA.manager.objects[1].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[1].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[1].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[1].attributes[0].trick_name      = 'P.sim_data.time'
+THLA.manager.objects[1].attributes[0].trick_name      = 'P.packing.time'
 THLA.manager.objects[1].attributes[0].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[0].subscribe       = True
 THLA.manager.objects[1].attributes[0].locally_owned   = False
 THLA.manager.objects[1].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[1].attributes[1].trick_name      = 'P.sim_data.value'
+THLA.manager.objects[1].attributes[1].trick_name      = 'P.packing.value'
 THLA.manager.objects[1].attributes[1].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[1].publish         = True
 THLA.manager.objects[1].attributes[1].subscribe       = True
@@ -233,7 +232,7 @@ THLA.manager.objects[1].attributes[1].locally_owned   = False
 THLA.manager.objects[1].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[1].attributes[2].trick_name      = 'P.sim_data.dvdt'
+THLA.manager.objects[1].attributes[2].trick_name      = 'P.packing.dvdt'
 THLA.manager.objects[1].attributes[2].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[2].publish         = True
 THLA.manager.objects[1].attributes[2].subscribe       = True
@@ -248,28 +247,28 @@ THLA.manager.objects[1].attributes[3].locally_owned   = False
 THLA.manager.objects[1].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[1].attributes[4].trick_name      = 'P.sim_data.freq'
+THLA.manager.objects[1].attributes[4].trick_name      = 'P.packing.freq'
 THLA.manager.objects[1].attributes[4].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[4].subscribe       = True
 THLA.manager.objects[1].attributes[4].locally_owned   = False
 THLA.manager.objects[1].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[1].attributes[5].trick_name      = 'P.sim_data.amp'
+THLA.manager.objects[1].attributes[5].trick_name      = 'P.packing.amp'
 THLA.manager.objects[1].attributes[5].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[5].subscribe       = True
 THLA.manager.objects[1].attributes[5].locally_owned   = False
 THLA.manager.objects[1].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[1].attributes[6].trick_name      = 'P.sim_data.tol'
+THLA.manager.objects[1].attributes[6].trick_name      = 'P.packing.tol'
 THLA.manager.objects[1].attributes[6].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[6].subscribe       = True
 THLA.manager.objects[1].attributes[6].locally_owned   = False
 THLA.manager.objects[1].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[1].attributes[7].trick_name      = 'P.sim_data.name'
+THLA.manager.objects[1].attributes[7].trick_name      = 'P.packing.name'
 THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[7].subscribe       = True
 THLA.manager.objects[1].attributes[7].locally_owned   = False

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_p_side/input.py
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_p_side/input.py
@@ -6,7 +6,7 @@
 trick.exec_set_trap_sigfpe(True)
 #trick.checkpoint_pre_init(1)
 trick.checkpoint_post_init(1)
-#trick.add_read(0.0 , '''trick.checkpoint('chkpnt_point')''')
+#trick.add_read(0.0 , '''trick.checkpoint('checkpoint')''')
 
 # NOTE: You must set this to be the same as the master federate's frame for IMSim freezing
 trick.exec_set_software_frame(0.25)
@@ -156,7 +156,7 @@ THLA.manager.objects[0].attr_count          = 8
 THLA.manager.objects[0].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[0].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[0].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[0].attributes[0].trick_name      = 'A.sim_data.time'
+THLA.manager.objects[0].attributes[0].trick_name      = 'A.packing.time'
 THLA.manager.objects[0].attributes[0].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[0].publish         = True
 THLA.manager.objects[0].attributes[0].subscribe       = True
@@ -164,7 +164,7 @@ THLA.manager.objects[0].attributes[0].locally_owned   = False
 THLA.manager.objects[0].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[0].attributes[1].trick_name      = 'A.sim_data.value'
+THLA.manager.objects[0].attributes[1].trick_name      = 'A.packing.value'
 THLA.manager.objects[0].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[1].publish         = True
 THLA.manager.objects[0].attributes[1].subscribe       = True
@@ -172,7 +172,7 @@ THLA.manager.objects[0].attributes[1].locally_owned   = False
 THLA.manager.objects[0].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[0].attributes[2].trick_name      = 'A.sim_data.dvdt'
+THLA.manager.objects[0].attributes[2].trick_name      = 'A.packing.dvdt'
 THLA.manager.objects[0].attributes[2].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[2].publish         = True
 THLA.manager.objects[0].attributes[2].subscribe       = True
@@ -188,7 +188,7 @@ THLA.manager.objects[0].attributes[3].locally_owned   = False
 THLA.manager.objects[0].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[0].attributes[4].trick_name      = 'A.sim_data.freq'
+THLA.manager.objects[0].attributes[4].trick_name      = 'A.packing.freq'
 THLA.manager.objects[0].attributes[4].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[4].publish         = True
 THLA.manager.objects[0].attributes[4].subscribe       = True
@@ -196,7 +196,7 @@ THLA.manager.objects[0].attributes[4].locally_owned   = False
 THLA.manager.objects[0].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[0].attributes[5].trick_name      = 'A.sim_data.amp'
+THLA.manager.objects[0].attributes[5].trick_name      = 'A.packing.amp'
 THLA.manager.objects[0].attributes[5].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[5].publish         = True
 THLA.manager.objects[0].attributes[5].subscribe       = True
@@ -204,7 +204,7 @@ THLA.manager.objects[0].attributes[5].locally_owned   = False
 THLA.manager.objects[0].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[0].attributes[6].trick_name      = 'A.sim_data.tol'
+THLA.manager.objects[0].attributes[6].trick_name      = 'A.packing.tol'
 THLA.manager.objects[0].attributes[6].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[6].publish         = True
 THLA.manager.objects[0].attributes[6].subscribe       = True
@@ -212,7 +212,7 @@ THLA.manager.objects[0].attributes[6].locally_owned   = False
 THLA.manager.objects[0].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[0].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[0].attributes[7].trick_name      = 'A.sim_data.name'
+THLA.manager.objects[0].attributes[7].trick_name      = 'A.packing.name'
 THLA.manager.objects[0].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[0].attributes[7].publish         = True
 THLA.manager.objects[0].attributes[7].subscribe       = True
@@ -231,14 +231,14 @@ THLA.manager.objects[1].attr_count          = 8
 THLA.manager.objects[1].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[1].attr_count, 'TrickHLA::Attribute' )
 
 THLA.manager.objects[1].attributes[0].FOM_name        = 'Time'
-THLA.manager.objects[1].attributes[0].trick_name      = 'P.sim_data.time'
+THLA.manager.objects[1].attributes[0].trick_name      = 'P.packing.time'
 THLA.manager.objects[1].attributes[0].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[0].publish         = True
 THLA.manager.objects[1].attributes[0].locally_owned   = True
 THLA.manager.objects[1].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[1].FOM_name        = 'Value'
-THLA.manager.objects[1].attributes[1].trick_name      = 'P.sim_data.value'
+THLA.manager.objects[1].attributes[1].trick_name      = 'P.packing.value'
 THLA.manager.objects[1].attributes[1].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[1].publish         = True
 THLA.manager.objects[1].attributes[1].subscribe       = True
@@ -246,7 +246,7 @@ THLA.manager.objects[1].attributes[1].locally_owned   = True
 THLA.manager.objects[1].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[2].FOM_name        = 'dvdt'
-THLA.manager.objects[1].attributes[2].trick_name      = 'P.sim_data.dvdt'
+THLA.manager.objects[1].attributes[2].trick_name      = 'P.packing.dvdt'
 THLA.manager.objects[1].attributes[2].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[2].publish         = True
 THLA.manager.objects[1].attributes[2].locally_owned   = True
@@ -260,28 +260,28 @@ THLA.manager.objects[1].attributes[3].locally_owned   = True
 THLA.manager.objects[1].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[4].FOM_name        = 'Frequency'
-THLA.manager.objects[1].attributes[4].trick_name      = 'P.sim_data.freq'
+THLA.manager.objects[1].attributes[4].trick_name      = 'P.packing.freq'
 THLA.manager.objects[1].attributes[4].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[4].publish         = True
 THLA.manager.objects[1].attributes[4].locally_owned   = True
 THLA.manager.objects[1].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[5].FOM_name        = 'Amplitude'
-THLA.manager.objects[1].attributes[5].trick_name      = 'P.sim_data.amp'
+THLA.manager.objects[1].attributes[5].trick_name      = 'P.packing.amp'
 THLA.manager.objects[1].attributes[5].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[5].publish         = True
 THLA.manager.objects[1].attributes[5].locally_owned   = True
 THLA.manager.objects[1].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[6].FOM_name        = 'Tolerance'
-THLA.manager.objects[1].attributes[6].trick_name      = 'P.sim_data.tol'
+THLA.manager.objects[1].attributes[6].trick_name      = 'P.packing.tol'
 THLA.manager.objects[1].attributes[6].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[6].publish         = True
 THLA.manager.objects[1].attributes[6].locally_owned   = True
 THLA.manager.objects[1].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
 
 THLA.manager.objects[1].attributes[7].FOM_name        = 'Name'
-THLA.manager.objects[1].attributes[7].trick_name      = 'P.sim_data.name'
+THLA.manager.objects[1].attributes[7].trick_name      = 'P.packing.name'
 THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_ZERO_LOOKAHEAD
 THLA.manager.objects[1].attributes[7].publish         = True
 THLA.manager.objects[1].attributes[7].locally_owned   = True

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/S_define
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/S_define
@@ -29,7 +29,6 @@
 
 ##include "sine/include/SineData.hh"
 ##include "sine/include/SinePacking.hh"
-##include "sine/include/SineLagCompensation.hh"
 ##include "sine/include/SineOwnershipHandler.hh"
 ##include "sine/include/SineInteractionHandler.hh"
 ##include "sine/include/SineObjectDeleted.hh"
@@ -56,8 +55,6 @@ class AnalyticSineSimObj : public THLAFedSimObject {
 
    TrickHLAModel::SinePacking            packing;
 
-   TrickHLAModel::SineLagCompensation    lag_compensation;
-
    TrickHLAModel::SineInteractionHandler interaction_handler;
 
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
@@ -67,8 +64,6 @@ class AnalyticSineSimObj : public THLAFedSimObject {
    {
       P50 ("initialization") packing.initialize( &sim_data );
 
-      P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
-      
       // HLA Data will only be received if it is remotely owned by another federate.
       (THLA_DATA_CYCLE_TIME, "scheduled") federate.wait_to_receive_zero_lookahead_data( "A-side-Federate.Test" );
 
@@ -104,8 +99,6 @@ class PropagatedSineSimObj : public THLAFedSimObject {
 
    TrickHLAModel::SinePacking            packing;
 
-   TrickHLAModel::SineLagCompensation    lag_compensation;
-
    TrickHLAModel::SineInteractionHandler interaction_handler;
 
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
@@ -116,8 +109,6 @@ class PropagatedSineSimObj : public THLAFedSimObject {
       // Note: Make sure to initialize the data before it gets sent in
       // the THLA_INIT simulation object.
       P50 ("initialization") packing.initialize( &sim_data );
-
-      P50 ("initialization") lag_compensation.initialize( &sim_data, &lag_comp_data );
 
       // HLA Data will only be received if it is remotely owned by another federate.
       (THLA_DATA_CYCLE_TIME, "scheduled") federate.wait_to_receive_zero_lookahead_data( "P-side-Federate.Test" );

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/S_define
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/S_define
@@ -29,7 +29,6 @@
 
 ##include "sine/include/SineData.hh"
 ##include "sine/include/SinePacking.hh"
-##include "sine/include/SineOwnershipHandler.hh"
 ##include "sine/include/SineInteractionHandler.hh"
 ##include "sine/include/SineObjectDeleted.hh"
 
@@ -49,9 +48,6 @@ class AnalyticSineSimObj : public THLAFedSimObject {
  public:
    TrickHLAModel::SineData truth_data;
    TrickHLAModel::SineData sim_data;
-   TrickHLAModel::SineData lag_comp_data;
-
-   TrickHLAModel::SineOwnershipHandler   ownership_handler;
 
    TrickHLAModel::SinePacking            packing;
 
@@ -95,7 +91,6 @@ class PropagatedSineSimObj : public THLAFedSimObject {
  public:
    TrickHLAModel::SineData truth_data;
    TrickHLAModel::SineData sim_data;
-   TrickHLAModel::SineData lag_comp_data;
 
    TrickHLAModel::SinePacking            packing;
 

--- a/source/SpaceFOM/QuaternionEncoder.cpp
+++ b/source/SpaceFOM/QuaternionEncoder.cpp
@@ -43,7 +43,7 @@ NASA, Johnson Space Center\n
 #include "RTI/VariableLengthData.h"
 #pragma GCC diagnostic pop
 
-using namespace rti1516e;
+using namespace RTI1516_NAMESPACE;
 using namespace std;
 using namespace SpaceFOM;
 

--- a/source/SpaceFOM/SpaceTimeCoordinateEncoder.cpp
+++ b/source/SpaceFOM/SpaceTimeCoordinateEncoder.cpp
@@ -44,7 +44,7 @@ NASA, Johnson Space Center\n
 #include "RTI/VariableLengthData.h"
 #pragma GCC diagnostic pop
 
-using namespace rti1516e;
+using namespace RTI1516_NAMESPACE;
 using namespace std;
 using namespace SpaceFOM;
 

--- a/source/TrickHLA/Federate.cpp
+++ b/source/TrickHLA/Federate.cpp
@@ -3586,12 +3586,12 @@ void Federate::create_federation()
       this->federation_exists              = false;
 
       wstring          MIM_module_ws = L"";
-      VectorOfWstrings fomModulesVector;
+      VectorOfWstrings FOM_modules_vector;
 
       // Add the user specified FOM-modules to the vector by parsing the comma
       // separated list of modules.
       if ( FOM_modules != NULL ) {
-         StringUtilities::tokenize( FOM_modules, fomModulesVector, "," );
+         StringUtilities::tokenize( FOM_modules, FOM_modules_vector, "," );
       }
 
       // Determine if the user specified a MIM-module, which determines how
@@ -3603,12 +3603,12 @@ void Federate::create_federation()
       if ( MIM_module_ws.empty() ) {
          // Create the Federation execution.
          RTI_ambassador->createFederationExecution( federation_name_ws,
-                                                    fomModulesVector,
+                                                    FOM_modules_vector,
                                                     L"HLAinteger64Time" );
       } else {
          // Create the Federation execution with a user specified MIM.
          RTI_ambassador->createFederationExecutionWithMIM( federation_name_ws,
-                                                           fomModulesVector,
+                                                           FOM_modules_vector,
                                                            MIM_module_ws,
                                                            L"HLAinteger64Time" );
       }

--- a/source/TrickHLA/Federate.cpp
+++ b/source/TrickHLA/Federate.cpp
@@ -4962,17 +4962,6 @@ void Federate::associate_to_trick_child_thread(
                __LINE__, thread_id, data_cycle, THLA_NEWLINE );
    }
 
-   // For now, do not allow Trick child threads for a zero lookahead time
-   // because the API's to assist with getting zero lookahead cyclic data are
-   // not thread safe at this point.
-   if ( ( this->lookahead_time <= 0.0 ) && ( thread_id != 0 ) ) {
-      ostringstream errmsg;
-      errmsg << "Federate::associate_to_trick_child_thread():" << __LINE__
-             << " ERROR: Associated Trick child threads are not supported when"
-             << " a zero-lookahead time is used." << THLA_ENDL;
-      DebugHandler::terminate_with_message( errmsg.str() );
-   }
-
    // Delegate to the Trick child thread coordinator.
    this->thread_coordinator.associate_to_trick_child_thread( thread_id, data_cycle );
 }

--- a/source/TrickHLA/LagCompensation.cpp
+++ b/source/TrickHLA/LagCompensation.cpp
@@ -30,6 +30,7 @@ NASA, Johnson Space Center\n
 @rev_entry{Dan Dexter, L3 Titan Group, DSES, June 2006, --, DSES Initial Lag Compensation.}
 @rev_entry{Dan Dexter, NASA ER7, TrickHLA, March 2019, --, Version 2 origin.}
 @rev_entry{Edwin Z. Crues, NASA ER7, TrickHLA, March 2019, --, Version 3 rewrite.}
+@rev_entry{Dan Dexter, NASA ER6, TrickHLA, October 2023, --, Added lag-comp bypass functions.}
 @revs_end
 
 */
@@ -64,26 +65,6 @@ void LagCompensation::initialize_callback(
    Object *obj )
 {
    this->object = obj;
-}
-
-void LagCompensation::send_lag_compensation()
-{
-   ostringstream errmsg;
-   errmsg << "LagCompensation::send_lag_compensation():" << __LINE__
-          << " ERROR: Your class that extends LagCompensation must implement"
-          << " the 'virtual void send_lag_compensation()' function!"
-          << THLA_ENDL;
-   DebugHandler::terminate_with_message( errmsg.str() );
-}
-
-void LagCompensation::receive_lag_compensation()
-{
-   ostringstream errmsg;
-   errmsg << "LagCompensation::receive_lag_compensation():" << __LINE__
-          << " ERROR: Your class that extends LagCompensation must implement"
-          << " the 'virtual void receive_lag_compensation()' function!"
-          << THLA_ENDL;
-   DebugHandler::terminate_with_message( errmsg.str() );
 }
 
 Attribute *LagCompensation::get_attribute(
@@ -130,20 +111,18 @@ Int64Interval LagCompensation::get_lookahead() const
 {
    if ( object != NULL ) {
       return object->get_lookahead();
-   } else {
-      Int64Interval di( -1.0 );
-      return di;
    }
+   Int64Interval di( -1.0 );
+   return di;
 }
 
 Int64Time LagCompensation::get_granted_time() const
 {
    if ( object != NULL ) {
       return object->get_granted_time();
-   } else {
-      Int64Time dt( Int64BaseTime::get_max_logical_time_in_seconds() );
-      return dt;
    }
+   Int64Time dt( Int64BaseTime::get_max_logical_time_in_seconds() );
+   return dt;
 }
 
 double LagCompensation::get_scenario_time()

--- a/source/TrickHLA/LagCompensation.cpp
+++ b/source/TrickHLA/LagCompensation.cpp
@@ -67,6 +67,36 @@ void LagCompensation::initialize_callback(
    this->object = obj;
 }
 
+/*!
+ * @brief Send side lag compensation callback.
+ */
+void LagCompensation::send_lag_compensation()
+{
+   ostringstream errmsg;
+   errmsg << "LagCompensation::send_lag_compensation():" << __LINE__
+          << " ERROR: Your class that extends LagCompensation must implement"
+          << " the 'virtual void send_lag_compensation()' function!"
+          << THLA_ENDL;
+   DebugHandler::terminate_with_message( errmsg.str() );
+}
+
+/*!
+ * @brief Receive side lag compensation callback.
+ */
+void LagCompensation::receive_lag_compensation()
+{
+   ostringstream errmsg;
+   errmsg << "LagCompensation::receive_lag_compensation():" << __LINE__
+          << " ERROR: Your class that extends LagCompensation must implement"
+          << " the 'virtual void receive_lag_compensation()' function!"
+          << THLA_ENDL;
+   DebugHandler::terminate_with_message( errmsg.str() );
+}
+
+/*! @brief Get the Attribute by FOM name.
+ *  @return Attribute for the given name.
+ *  @param attr_FOM_name Attribute FOM name.
+ */
 Attribute *LagCompensation::get_attribute(
    char const *attr_FOM_name )
 {
@@ -107,6 +137,9 @@ Attribute *LagCompensation::get_attribute_and_validate(
    return attr;
 }
 
+/*! @brief Returns a copy of the object's lookahead time.
+ *  @return A copy of the federate's lookahead time.
+ */
 Int64Interval LagCompensation::get_lookahead() const
 {
    if ( object != NULL ) {
@@ -116,6 +149,9 @@ Int64Interval LagCompensation::get_lookahead() const
    return di;
 }
 
+/*! @brief Returns a copy of the object's granted federation time.
+ *  @return A copy of the federate's current granted time.
+ */
 Int64Time LagCompensation::get_granted_time() const
 {
    if ( object != NULL ) {
@@ -125,6 +161,9 @@ Int64Time LagCompensation::get_granted_time() const
    return dt;
 }
 
+/*! @brief Returns the current scenario time.
+ *  @return Current scenario time.
+ */
 double LagCompensation::get_scenario_time()
 {
    if ( ( object != NULL ) && ( object->get_federate() != NULL ) ) {
@@ -134,6 +173,9 @@ double LagCompensation::get_scenario_time()
    return -std::numeric_limits< double >::max();
 }
 
+/*! @brief Returns the current Central Timing Equipment (CTE) time.
+ *  @return Current CTE time.
+ */
 double LagCompensation::get_cte_time()
 {
    if ( ( object != NULL ) && ( object->get_federate() != NULL ) ) {

--- a/source/TrickHLA/Object.cpp
+++ b/source/TrickHLA/Object.cpp
@@ -1661,9 +1661,24 @@ void Object::send_requested_data(
    // mutex even if there is an exception.
    MutexProtection auto_unlock_mutex( &send_mutex );
 
-   // Do send side lag compensation.
-   if ( ( lag_comp_type == LAG_COMPENSATION_SEND_SIDE ) && ( lag_comp != NULL ) ) {
-      lag_comp->send_lag_compensation();
+   // Do lag compensation.
+   if ( lag_comp != NULL ) {
+      switch ( lag_comp_type ) {
+         case LAG_COMPENSATION_SEND_SIDE:
+            lag_comp->send_lag_compensation();
+            break;
+         case LAG_COMPENSATION_RECEIVE_SIDE:
+            // There are locally owned attributes that are published by this
+            // federate that we need to send even tough Received-side lag
+            // compensation has been configured. Maybe a result of attribute
+            // ownership transfer.
+            lag_comp->bypass_send_lag_compensation();
+            break;
+         case LAG_COMPENSATION_NONE:
+         default:
+            lag_comp->bypass_send_lag_compensation();
+            break;
+      }
    }
 
    // If we have a data packing object then pack the data now.
@@ -1906,9 +1921,24 @@ void Object::send_cyclic_and_requested_data(
    // mutex even if there is an exception.
    MutexProtection auto_unlock_mutex( &send_mutex );
 
-   // Do send side lag compensation.
-   if ( ( lag_comp_type == LAG_COMPENSATION_SEND_SIDE ) && ( lag_comp != NULL ) ) {
-      lag_comp->send_lag_compensation();
+   // Do lag compensation.
+   if ( lag_comp != NULL ) {
+      switch ( lag_comp_type ) {
+         case LAG_COMPENSATION_SEND_SIDE:
+            lag_comp->send_lag_compensation();
+            break;
+         case LAG_COMPENSATION_RECEIVE_SIDE:
+            // There are locally owned attributes that are published by this
+            // federate that we need to send even tough Received-side lag
+            // compensation has been configured. Maybe a result of attribute
+            // ownership transfer.
+            lag_comp->bypass_send_lag_compensation();
+            break;
+         case LAG_COMPENSATION_NONE:
+         default:
+            lag_comp->bypass_send_lag_compensation();
+            break;
+      }
    }
 
    // If we have a data packing object then pack the data now.
@@ -2157,9 +2187,24 @@ void Object::send_zero_lookahead_and_requested_data(
    // mutex even if there is an exception.
    MutexProtection auto_unlock_mutex( &send_mutex );
 
-   // Do send side lag compensation.
-   if ( ( lag_comp_type == LAG_COMPENSATION_SEND_SIDE ) && ( lag_comp != NULL ) ) {
-      lag_comp->send_lag_compensation();
+   // Do lag compensation.
+   if ( lag_comp != NULL ) {
+      switch ( lag_comp_type ) {
+         case LAG_COMPENSATION_SEND_SIDE:
+            lag_comp->send_lag_compensation();
+            break;
+         case LAG_COMPENSATION_RECEIVE_SIDE:
+            // There are locally owned attributes that are published by this
+            // federate that we need to send even tough Received-side lag
+            // compensation has been configured. Maybe a result of attribute
+            // ownership transfer.
+            lag_comp->bypass_send_lag_compensation();
+            break;
+         case LAG_COMPENSATION_NONE:
+         default:
+            lag_comp->bypass_send_lag_compensation();
+            break;
+      }
    }
 
    // If we have a data packing object then pack the data now.
@@ -2484,9 +2529,24 @@ void Object::receive_cyclic_data()
             packing->unpack();
          }
 
-         // Do receive side lag compensation.
-         if ( ( lag_comp_type == LAG_COMPENSATION_RECEIVE_SIDE ) && ( lag_comp != NULL ) ) {
-            lag_comp->receive_lag_compensation();
+         // Do lag compensation.
+         if ( lag_comp != NULL ) {
+            switch ( lag_comp_type ) {
+               case LAG_COMPENSATION_RECEIVE_SIDE:
+                  lag_comp->receive_lag_compensation();
+                  break;
+               case LAG_COMPENSATION_SEND_SIDE:
+                  // There are remotely owned attributes that are subscribed by
+                  // this federate that we need to receive even tough Send-side
+                  // lag compensation has been configured. Maybe a result of
+                  // attribute ownership transfer.
+                  lag_comp->bypass_receive_lag_compensation();
+                  break;
+               case LAG_COMPENSATION_NONE:
+               default:
+                  lag_comp->bypass_receive_lag_compensation();
+                  break;
+            }
          }
 
          // Mark this data as unchanged now that we have processed it from the buffer.
@@ -2549,8 +2609,23 @@ void Object::receive_zero_lookahead_data()
          }
 
          // Do receive side lag compensation.
-         if ( ( lag_comp_type == LAG_COMPENSATION_RECEIVE_SIDE ) && ( lag_comp != NULL ) ) {
-            lag_comp->receive_lag_compensation();
+         if ( lag_comp != NULL ) {
+            switch ( lag_comp_type ) {
+               case LAG_COMPENSATION_RECEIVE_SIDE:
+                  lag_comp->receive_lag_compensation();
+                  break;
+               case LAG_COMPENSATION_SEND_SIDE:
+                  // There are remotely owned attributes that are subscribed by
+                  // this federate that we need to receive even tough Send-side
+                  // lag compensation has been configured. Maybe a result of
+                  // attribute ownership transfer.
+                  lag_comp->bypass_receive_lag_compensation();
+                  break;
+               case LAG_COMPENSATION_NONE:
+               default:
+                  lag_comp->bypass_receive_lag_compensation();
+                  break;
+            }
          }
 
          // Mark this data as unchanged now that we have processed it from the buffer.

--- a/source/TrickHLA/Packing.cpp
+++ b/source/TrickHLA/Packing.cpp
@@ -69,12 +69,21 @@ Packing::~Packing()
    return;
 }
 
+/*!
+ * @brief Initialize the callback object to the supplied Object pointer.
+ * @param obj Associated object for this class.
+ */
 void Packing::initialize_callback(
    Object *obj )
 {
    this->object = obj;
 }
 
+/*!
+ * @brief Get the Attribute by FOM name.
+ * @return Attribute for the given name.
+ * @param attr_FOM_name Attribute FOM name.
+ */
 Attribute *Packing::get_attribute(
    char const *attr_FOM_name )
 {
@@ -82,8 +91,9 @@ Attribute *Packing::get_attribute(
 }
 
 /*!
- *  @details If the attribute is not found then an error message is displayed
- *  then exec-terminate is called.
+ * @brief This function returns the Attribute for the given attribute FOM name.
+ * @return Attribute for the given name.
+ * @param attr_FOM_name Attribute FOM name.
  */
 Attribute *Packing::get_attribute_and_validate(
    char const *attr_FOM_name )
@@ -115,6 +125,10 @@ Attribute *Packing::get_attribute_and_validate(
    return attr;
 }
 
+/*!
+ * @brief Get the current scenario time.
+ * @return Returns the current scenario time.
+ */
 double Packing::get_scenario_time()
 {
    if ( ( object != NULL ) && ( object->get_federate() != NULL ) ) {
@@ -124,6 +138,10 @@ double Packing::get_scenario_time()
    return -std::numeric_limits< double >::max();
 }
 
+/*!
+ * @brief Get the current Central Timing Equipment (CTE) time.
+ * @return Returns the current CTE time.
+ */
 double Packing::get_cte_time()
 {
    if ( ( object != NULL ) && ( object->get_federate() != NULL ) ) {


### PR DESCRIPTION
Updated the lag-compensation API to support disabling lag-comp and to handle the case of ownership transfer when the object attributes are configured for lag-compensation. See issue #128.