### PR TITLE
Zero lookahead with cyclic data updates.

### DIFF
--- a/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_a_side/input.py
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_a_side/input.py
@@ -24,6 +24,8 @@ run_duration = 15.0
 exec(open( "Log_data/log_sine_states.py" ).read())
 log_sine_states( 'A', 0.250 )
 log_sine_states( 'P', 0.250 )
+log_sine_states( 'AC', 0.250 )
+log_sine_states( 'PC', 0.250 )
 
 
 #---------------------------------------------
@@ -37,11 +39,17 @@ A.packing.buff_size = 10
 A.packing.buff = trick.sim_services.alloc_type( A.packing.buff_size, 'unsigned char' )
 P.packing.buff_size = 10
 P.packing.buff = trick.sim_services.alloc_type( P.packing.buff_size, 'unsigned char' )
+AC.packing.buff_size = 10
+AC.packing.buff = trick.sim_services.alloc_type( A.packing.buff_size, 'unsigned char' )
+PC.packing.buff_size = 10
+PC.packing.buff = trick.sim_services.alloc_type( P.packing.buff_size, 'unsigned char' )
 
 # We are taking advantage of the input file to specify a unique name for the
 # sim-data name field for the A-side federate.
-A.sim_data.name = 'A.sim_data.name.A-side'
-P.sim_data.name = 'P.sim_data.name.A-side'
+A.sim_data.name  = 'A.sim_data.name.A-side'
+P.sim_data.name  = 'P.sim_data.name.A-side'
+AC.sim_data.name = 'AC.sim_data.name.A-side.cyclic'
+PC.sim_data.name = 'PC.sim_data.name.A-side.cyclic'
 
 # We are taking advantage of the input file to specify a unique name and
 # message for the A-side federate interaction handler.
@@ -136,7 +144,7 @@ THLA.manager.interactions[0].parameters[2].rti_encoding = trick.ENCODING_LITTLE_
 
 
 # The Federate has two objects, it publishes one and subscribes to another.
-THLA.manager.obj_count = 2
+THLA.manager.obj_count = 4
 THLA.manager.objects   = trick.sim_services.alloc_type( THLA.manager.obj_count, 'TrickHLA::Object' )
 
 # Configure the object this federate will create an HLA instance and
@@ -273,6 +281,139 @@ THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_ZERO_LOOKAH
 THLA.manager.objects[1].attributes[7].subscribe       = True
 THLA.manager.objects[1].attributes[7].locally_owned   = False
 THLA.manager.objects[1].attributes[7].rti_encoding    = trick.ENCODING_UNICODE_STRING
+
+# Cyclic analytic state.
+THLA.manager.objects[2].FOM_name            = 'Test'
+THLA.manager.objects[2].name                = 'A-side-Federate.Test.cyclic'
+THLA.manager.objects[2].create_HLA_instance = True
+THLA.manager.objects[2].packing             = AC.packing
+THLA.manager.objects[2].deleted             = AC.obj_deleted_callback
+THLA.manager.objects[2].attr_count          = 8
+THLA.manager.objects[2].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[2].attr_count, 'TrickHLA::Attribute' )
+
+THLA.manager.objects[2].attributes[0].FOM_name        = 'Time'
+THLA.manager.objects[2].attributes[0].trick_name      = 'AC.packing.time'
+THLA.manager.objects[2].attributes[0].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[0].publish         = True
+THLA.manager.objects[2].attributes[0].locally_owned   = True
+THLA.manager.objects[2].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[1].FOM_name        = 'Value'
+THLA.manager.objects[2].attributes[1].trick_name      = 'AC.packing.value'
+THLA.manager.objects[2].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[1].publish         = True
+THLA.manager.objects[2].attributes[1].subscribe       = True
+THLA.manager.objects[2].attributes[1].locally_owned   = True
+THLA.manager.objects[2].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[2].FOM_name        = 'dvdt'
+THLA.manager.objects[2].attributes[2].trick_name      = 'AC.packing.dvdt'
+THLA.manager.objects[2].attributes[2].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[2].publish         = True
+THLA.manager.objects[2].attributes[2].locally_owned   = True
+THLA.manager.objects[2].attributes[2].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[3].FOM_name        = 'Phase'
+THLA.manager.objects[2].attributes[3].trick_name      = 'AC.packing.phase_deg' # using packed data instead of 'A.sim_data.phase'
+THLA.manager.objects[2].attributes[3].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[3].publish         = True
+THLA.manager.objects[2].attributes[3].locally_owned   = True
+THLA.manager.objects[2].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[4].FOM_name        = 'Frequency'
+THLA.manager.objects[2].attributes[4].trick_name      = 'AC.packing.freq'
+THLA.manager.objects[2].attributes[4].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[4].publish         = True
+THLA.manager.objects[2].attributes[4].locally_owned   = True
+THLA.manager.objects[2].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[5].FOM_name        = 'Amplitude'
+THLA.manager.objects[2].attributes[5].trick_name      = 'AC.packing.amp'
+THLA.manager.objects[2].attributes[5].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[5].publish         = True
+THLA.manager.objects[2].attributes[5].locally_owned   = True
+THLA.manager.objects[2].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[6].FOM_name        = 'Tolerance'
+THLA.manager.objects[2].attributes[6].trick_name      = 'AC.packing.tol'
+THLA.manager.objects[2].attributes[6].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[6].publish         = True
+THLA.manager.objects[2].attributes[6].locally_owned   = True
+THLA.manager.objects[2].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[7].FOM_name        = 'Name'
+THLA.manager.objects[2].attributes[7].trick_name      = 'AC.packing.name'
+THLA.manager.objects[2].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[7].publish         = True
+THLA.manager.objects[2].attributes[7].locally_owned   = True
+THLA.manager.objects[2].attributes[7].rti_encoding    = trick.ENCODING_UNICODE_STRING
+
+# Cyclic propagated state.
+THLA.manager.objects[3].FOM_name            = 'Test'
+THLA.manager.objects[3].name                = 'P-side-Federate.Test.cyclic'
+THLA.manager.objects[3].create_HLA_instance = False
+THLA.manager.objects[3].packing             = PC.packing
+THLA.manager.objects[3].deleted             = PC.obj_deleted_callback
+THLA.manager.objects[3].attr_count          = 8
+THLA.manager.objects[3].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[3].attr_count, 'TrickHLA::Attribute' )
+
+THLA.manager.objects[3].attributes[0].FOM_name        = 'Time'
+THLA.manager.objects[3].attributes[0].trick_name      = 'PC.packing.time'
+THLA.manager.objects[3].attributes[0].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[0].subscribe       = True
+THLA.manager.objects[3].attributes[0].locally_owned   = False
+THLA.manager.objects[3].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[1].FOM_name        = 'Value'
+THLA.manager.objects[3].attributes[1].trick_name      = 'PC.packing.value'
+THLA.manager.objects[3].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[1].publish         = True
+THLA.manager.objects[3].attributes[1].subscribe       = True
+THLA.manager.objects[3].attributes[1].locally_owned   = False
+THLA.manager.objects[3].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[2].FOM_name        = 'dvdt'
+THLA.manager.objects[3].attributes[2].trick_name      = 'PC.packing.dvdt'
+THLA.manager.objects[3].attributes[2].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[2].publish         = True
+THLA.manager.objects[3].attributes[2].subscribe       = True
+THLA.manager.objects[3].attributes[2].locally_owned   = False
+THLA.manager.objects[3].attributes[2].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[3].FOM_name        = 'Phase'
+THLA.manager.objects[3].attributes[3].trick_name      = 'PC.packing.phase_deg' # using packed data instead of 'P.sim_data.phase'
+THLA.manager.objects[3].attributes[3].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[3].subscribe       = True
+THLA.manager.objects[3].attributes[3].locally_owned   = False
+THLA.manager.objects[3].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[4].FOM_name        = 'Frequency'
+THLA.manager.objects[3].attributes[4].trick_name      = 'PC.packing.freq'
+THLA.manager.objects[3].attributes[4].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[4].subscribe       = True
+THLA.manager.objects[3].attributes[4].locally_owned   = False
+THLA.manager.objects[3].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[5].FOM_name        = 'Amplitude'
+THLA.manager.objects[3].attributes[5].trick_name      = 'PC.packing.amp'
+THLA.manager.objects[3].attributes[5].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[5].subscribe       = True
+THLA.manager.objects[3].attributes[5].locally_owned   = False
+THLA.manager.objects[3].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[6].FOM_name        = 'Tolerance'
+THLA.manager.objects[3].attributes[6].trick_name      = 'PC.packing.tol'
+THLA.manager.objects[3].attributes[6].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[6].subscribe       = True
+THLA.manager.objects[3].attributes[6].locally_owned   = False
+THLA.manager.objects[3].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[7].FOM_name        = 'Name'
+THLA.manager.objects[3].attributes[7].trick_name      = 'PC.packing.name'
+THLA.manager.objects[3].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[7].subscribe       = True
+THLA.manager.objects[3].attributes[7].locally_owned   = False
+THLA.manager.objects[3].attributes[7].rti_encoding    = trick.ENCODING_UNICODE_STRING
 
 
 #---------------------------------------------

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_p_side/input.py
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/RUN_p_side/input.py
@@ -27,7 +27,8 @@ run_duration = 15.0
 exec(open( "Log_data/log_sine_states.py" ).read())
 log_sine_states( 'A', 0.250 )
 log_sine_states( 'P', 0.250 )
-
+log_sine_states( 'AC', 0.250 )
+log_sine_states( 'PC', 0.250 )
 
 #---------------------------------------------
 # Set up the initial Sine states
@@ -45,12 +46,18 @@ A.packing.buff_size = 10
 A.packing.buff = trick.sim_services.alloc_type( A.packing.buff_size, 'unsigned char' )
 P.packing.buff_size = 10
 P.packing.buff = trick.sim_services.alloc_type( P.packing.buff_size, 'unsigned char' )
+AC.packing.buff_size = 10
+AC.packing.buff = trick.sim_services.alloc_type( A.packing.buff_size, 'unsigned char' )
+PC.packing.buff_size = 10
+PC.packing.buff = trick.sim_services.alloc_type( P.packing.buff_size, 'unsigned char' )
 
 
 # We are taking advantage of the input file to specify a unique name for the
 # sim-data name field for the P-side federate.
-A.sim_data.name = 'A.name.P-side'
-P.sim_data.name = 'P.name.P-side'
+A.sim_data.name  = 'A.name.P-side'
+P.sim_data.name  = 'P.name.P-side'
+AC.sim_data.name = 'AC.name.P-side.cyclic'
+PC.sim_data.name = 'PC.name.P-side.cyclic'
 
 # We are taking advantage of the input file to specify a unique name and
 # message for the P-side federate interaction handler.
@@ -141,7 +148,7 @@ THLA.manager.interactions[0].parameters[2].rti_encoding = trick.ENCODING_LITTLE_
 
 
 # The Federate has two objects, it publishes one and subscribes to another.
-THLA.manager.obj_count = 2
+THLA.manager.obj_count = 4
 THLA.manager.objects   = trick.sim_services.alloc_type( THLA.manager.obj_count, 'TrickHLA::Object' )
 
 
@@ -286,6 +293,145 @@ THLA.manager.objects[1].attributes[7].config          = trick.CONFIG_ZERO_LOOKAH
 THLA.manager.objects[1].attributes[7].publish         = True
 THLA.manager.objects[1].attributes[7].locally_owned   = True
 THLA.manager.objects[1].attributes[7].rti_encoding    = trick.ENCODING_UNICODE_STRING
+
+# Cyclic analytic data.
+THLA.manager.objects[2].FOM_name            = 'Test'
+THLA.manager.objects[2].name                = 'A-side-Federate.Test.cyclic'
+THLA.manager.objects[2].create_HLA_instance = False
+THLA.manager.objects[2].packing             = AC.packing
+THLA.manager.objects[2].deleted             = AC.obj_deleted_callback
+THLA.manager.objects[2].attr_count          = 8
+THLA.manager.objects[2].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[2].attr_count, 'TrickHLA::Attribute' )
+
+THLA.manager.objects[2].attributes[0].FOM_name        = 'Time'
+THLA.manager.objects[2].attributes[0].trick_name      = 'AC.packing.time'
+THLA.manager.objects[2].attributes[0].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[0].publish         = True
+THLA.manager.objects[2].attributes[0].subscribe       = True
+THLA.manager.objects[2].attributes[0].locally_owned   = False
+THLA.manager.objects[2].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[1].FOM_name        = 'Value'
+THLA.manager.objects[2].attributes[1].trick_name      = 'AC.packing.value'
+THLA.manager.objects[2].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[1].publish         = True
+THLA.manager.objects[2].attributes[1].subscribe       = True
+THLA.manager.objects[2].attributes[1].locally_owned   = False
+THLA.manager.objects[2].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[2].FOM_name        = 'dvdt'
+THLA.manager.objects[2].attributes[2].trick_name      = 'AC.packing.dvdt'
+THLA.manager.objects[2].attributes[2].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[2].publish         = True
+THLA.manager.objects[2].attributes[2].subscribe       = True
+THLA.manager.objects[2].attributes[2].locally_owned   = False
+THLA.manager.objects[2].attributes[2].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[3].FOM_name        = 'Phase'
+THLA.manager.objects[2].attributes[3].trick_name      = 'AC.packing.phase_deg' # using packed data instead of 'A.sim_data.phase'
+THLA.manager.objects[2].attributes[3].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[3].publish         = True
+THLA.manager.objects[2].attributes[3].subscribe       = True
+THLA.manager.objects[2].attributes[3].locally_owned   = False
+THLA.manager.objects[2].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[4].FOM_name        = 'Frequency'
+THLA.manager.objects[2].attributes[4].trick_name      = 'AC.packing.freq'
+THLA.manager.objects[2].attributes[4].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[4].publish         = True
+THLA.manager.objects[2].attributes[4].subscribe       = True
+THLA.manager.objects[2].attributes[4].locally_owned   = False
+THLA.manager.objects[2].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[5].FOM_name        = 'Amplitude'
+THLA.manager.objects[2].attributes[5].trick_name      = 'AC.packing.amp'
+THLA.manager.objects[2].attributes[5].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[5].publish         = True
+THLA.manager.objects[2].attributes[5].subscribe       = True
+THLA.manager.objects[2].attributes[5].locally_owned   = False
+THLA.manager.objects[2].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[6].FOM_name        = 'Tolerance'
+THLA.manager.objects[2].attributes[6].trick_name      = 'AC.packing.tol'
+THLA.manager.objects[2].attributes[6].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[6].publish         = True
+THLA.manager.objects[2].attributes[6].subscribe       = True
+THLA.manager.objects[2].attributes[6].locally_owned   = False
+THLA.manager.objects[2].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[2].attributes[7].FOM_name        = 'Name'
+THLA.manager.objects[2].attributes[7].trick_name      = 'AC.packing.name'
+THLA.manager.objects[2].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[2].attributes[7].publish         = True
+THLA.manager.objects[2].attributes[7].subscribe       = True
+THLA.manager.objects[2].attributes[7].locally_owned   = False
+THLA.manager.objects[2].attributes[7].rti_encoding    = trick.ENCODING_UNICODE_STRING
+
+# Cyclic propagated data.
+THLA.manager.objects[3].FOM_name            = 'Test'
+THLA.manager.objects[3].name                = 'P-side-Federate.Test.cyclic'
+THLA.manager.objects[3].create_HLA_instance = True
+THLA.manager.objects[3].packing             = PC.packing
+THLA.manager.objects[3].deleted             = PC.obj_deleted_callback
+THLA.manager.objects[3].attr_count          = 8
+THLA.manager.objects[3].attributes          = trick.sim_services.alloc_type( THLA.manager.objects[3].attr_count, 'TrickHLA::Attribute' )
+
+THLA.manager.objects[3].attributes[0].FOM_name        = 'Time'
+THLA.manager.objects[3].attributes[0].trick_name      = 'PC.packing.time'
+THLA.manager.objects[3].attributes[0].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[0].publish         = True
+THLA.manager.objects[3].attributes[0].locally_owned   = True
+THLA.manager.objects[3].attributes[0].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[1].FOM_name        = 'Value'
+THLA.manager.objects[3].attributes[1].trick_name      = 'PC.packing.value'
+THLA.manager.objects[3].attributes[1].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[1].publish         = True
+THLA.manager.objects[3].attributes[1].subscribe       = True
+THLA.manager.objects[3].attributes[1].locally_owned   = True
+THLA.manager.objects[3].attributes[1].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[2].FOM_name        = 'dvdt'
+THLA.manager.objects[3].attributes[2].trick_name      = 'PC.packing.dvdt'
+THLA.manager.objects[3].attributes[2].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[2].publish         = True
+THLA.manager.objects[3].attributes[2].locally_owned   = True
+THLA.manager.objects[3].attributes[2].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[3].FOM_name        = 'Phase'
+THLA.manager.objects[3].attributes[3].trick_name      = 'PC.packing.phase_deg' # using packed data instead of 'P.sim_data.phase'
+THLA.manager.objects[3].attributes[3].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[3].publish         = True
+THLA.manager.objects[3].attributes[3].locally_owned   = True
+THLA.manager.objects[3].attributes[3].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[4].FOM_name        = 'Frequency'
+THLA.manager.objects[3].attributes[4].trick_name      = 'PC.packing.freq'
+THLA.manager.objects[3].attributes[4].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[4].publish         = True
+THLA.manager.objects[3].attributes[4].locally_owned   = True
+THLA.manager.objects[3].attributes[4].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[5].FOM_name        = 'Amplitude'
+THLA.manager.objects[3].attributes[5].trick_name      = 'PC.packing.amp'
+THLA.manager.objects[3].attributes[5].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[5].publish         = True
+THLA.manager.objects[3].attributes[5].locally_owned   = True
+THLA.manager.objects[3].attributes[5].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[6].FOM_name        = 'Tolerance'
+THLA.manager.objects[3].attributes[6].trick_name      = 'PC.packing.tol'
+THLA.manager.objects[3].attributes[6].config          = trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[6].publish         = True
+THLA.manager.objects[3].attributes[6].locally_owned   = True
+THLA.manager.objects[3].attributes[6].rti_encoding    = trick.ENCODING_LITTLE_ENDIAN
+
+THLA.manager.objects[3].attributes[7].FOM_name        = 'Name'
+THLA.manager.objects[3].attributes[7].trick_name      = 'PC.packing.name'
+THLA.manager.objects[3].attributes[7].config          = trick.CONFIG_INITIALIZE + trick.CONFIG_CYCLIC
+THLA.manager.objects[3].attributes[7].publish         = True
+THLA.manager.objects[3].attributes[7].locally_owned   = True
+THLA.manager.objects[3].attributes[7].rti_encoding    = trick.ENCODING_UNICODE_STRING
 
 #---------------------------------------------
 # Set up simulation termination time.

--- a/sims/TrickHLA/SIM_sine_zero_lookahead/S_define
+++ b/sims/TrickHLA/SIM_sine_zero_lookahead/S_define
@@ -53,7 +53,7 @@ class AnalyticSineSimObj : public THLAFedSimObject {
 
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
 
-   AnalyticSineSimObj( TrickHLA::Federate & thla_fed ) 
+   AnalyticSineSimObj( TrickHLA::Federate & thla_fed )
       : THLAFedSimObject( thla_fed )
    {
       P50 ("initialization") packing.configure( &sim_data );
@@ -73,7 +73,7 @@ class AnalyticSineSimObj : public THLAFedSimObject {
       // HLA Data will only be sent if this federate owns it.
       (THLA_DATA_CYCLE_TIME, "scheduled") federate.send_zero_lookahead_and_requested_data( "A-side-Federate.Test" );
    }
-   
+
  private:
    // Do not allow the implicit copy constructor or assignment operator.
    AnalyticSineSimObj( AnalyticSineSimObj const & rhs );
@@ -97,7 +97,7 @@ class PropagatedSineSimObj : public THLAFedSimObject {
 
    TrickHLAModel::SineObjectDeleted      obj_deleted_callback;
 
-   PropagatedSineSimObj( TrickHLA::Federate & thla_fed ) 
+   PropagatedSineSimObj( TrickHLA::Federate & thla_fed )
       : THLAFedSimObject( thla_fed )
    {
       // Note: Make sure to initialize the data before it gets sent in
@@ -161,19 +161,20 @@ class THLAInitSimObj : public Trick::SimObject {
    TrickHLA::ScenarioTimeline scenario_timeline;
 
    THLAInitSimObj( TrickHLA::Manager  & thla_mngr,
-                   TrickHLA::Federate & thla_fed ) 
+                   TrickHLA::Federate & thla_fed )
       : scenario_timeline( sim_timeline, 0.0, 0.0 ),
         thla_manager( thla_mngr ),
         thla_federate( thla_fed )
    {
       //------------------------------------------------------------------------
-      // NOTE: Initialization phase numbers must be greater than P60 
+      // NOTE: Initialization phase numbers must be greater than P60
       // (i.e. P_HLA_INIT) so that the initialization jobs run after the
       // P60 THLA.manager->initialize() job.
       //------------------------------------------------------------------------
 
       // Data will only be sent if this federate owns it.
       P100 ("initialization") thla_manager.send_init_data( "A-side-Federate.Test" );
+      P100 ("initialization") thla_manager.send_init_data( "A-side-Federate.Test.cyclic" );
 
       // Data will only be received if it is remotely owned by another federate.
   //    P100 ("initialization") thla_manager.receive_init_data( "A-side-Federate.Test" );
@@ -186,6 +187,7 @@ class THLAInitSimObj : public Trick::SimObject {
 
       // Data will only be sent if this federate owns it.
       P200 ("initialization") thla_manager.send_init_data( "P-side-Federate.Test" );
+      P200 ("initialization") thla_manager.send_init_data( "P-side-Federate.Test.cyclic" );
 
       // Data will only be received if it is remotely owned by another federate.
   //    P200 ("initialization") thla_manager.receive_init_data( "P-side-Federate.Test" );
@@ -224,13 +226,20 @@ class THLAInitSimObj : public Trick::SimObject {
 };
 
 
-// Instantiations
+// Instantiations used for Zero-Lookahead exchanges.
 AnalyticSineSimObj   A( THLA.federate );
 PropagatedSineSimObj P( THLA.federate );
+
+// Instantiations used for cyclic exchanges.
+AnalyticSineSimObj   AC( THLA.federate );
+PropagatedSineSimObj PC( THLA.federate );
+
+// Instantiation of multiphase initialization.
 THLAInitSimObj       THLA_INIT( THLA.manager, THLA.federate );
 
 // Define the simulation objects that have routines involved in integration.
-IntegLoop sim_integ_loop (DYN_RATE) P;
+IntegLoop sim_integ_loop (DYN_RATE)  P;
+IntegLoop sim_integ_loop2 (DYN_RATE) PC;
 
 // All code listed in the create_connections routine is copied into S_source.cpp
 // and is executed directly after sim-object instantiations. This routine may be
@@ -239,5 +248,6 @@ void create_connections() {
 
    // Assign a default integrator, which can be overridden in the input file.
    sim_integ_loop.getIntegrator( Runge_Kutta_4, 6 );
+   sim_integ_loop2.getIntegrator( Runge_Kutta_4, 6 );
 }
 


### PR DESCRIPTION
Cyclic data should be sent of cycle time even for zero lookahead.
Updated the example to send and receive both zero lookahead and cyclic data.